### PR TITLE
feat: 日本語化Fakerの導入とCompanyTestの更新 #34

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -2,8 +2,8 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Company extends Model
 {

--- a/database/migrations/2025_07_05_115213_create_companies_table.php
+++ b/database/migrations/2025_07_05_115213_create_companies_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('website_url', 500)->nullable()->comment('ウェブサイトURL');
             $table->boolean('is_active')->default(true)->comment('アクティブ状態');
             $table->timestamps();
-            
+
             // インデックス設定
             $table->index('name');
             $table->index('is_active');

--- a/docs/wiki/開発フロー.md
+++ b/docs/wiki/開発フロー.md
@@ -120,6 +120,25 @@ refactor/database-queries
    vendor/bin/phpstan analyse
    ```
 
+### テストでの日本語化Fakerの使用
+
+テストでは日本語のダミーデータを生成するため、Fakerの日本語化を行っています。
+
+```php
+// TestCase.php や各テストクラスで使用
+$faker = \Faker\Factory::create('ja_JP');
+
+// 例：日本語の会社名を生成
+$companyName = $faker->company;
+$personName = $faker->name;
+$email = $faker->email;
+$url = $faker->url;
+```
+
+**設定方法：**
+1. `tests/TestCase.php`でFakerの日本語化設定を追加
+2. 各テストクラスで`$this->faker()`メソッドを使用してアクセス
+
 4. **スクレイピング機能テスト**
    ```bash
    # キューワーカーの起動確認

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    //
+    /**
+     * 日本語化したFakerインスタンスを取得
+     */
+    protected function faker(): \Faker\Generator
+    {
+        return \Faker\Factory::create('ja_JP');
+    }
 }

--- a/tests/Unit/CompanyTest.php
+++ b/tests/Unit/CompanyTest.php
@@ -12,62 +12,73 @@ class CompanyTest extends TestCase
 
     public function test_company_can_be_created(): void
     {
+        $faker = $this->faker();
+        $companyName = $faker->company;
+        $domain = $faker->domainName;
+        $description = $faker->text(100);
+        $logoUrl = $faker->url;
+        $websiteUrl = $faker->url;
+
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
-            'description' => 'Test Description',
-            'logo_url' => 'https://example.com/logo.png',
-            'website_url' => 'https://test.com',
+            'name' => $companyName,
+            'domain' => $domain,
+            'description' => $description,
+            'logo_url' => $logoUrl,
+            'website_url' => $websiteUrl,
             'is_active' => true,
         ]);
 
         $this->assertInstanceOf(Company::class, $company);
-        $this->assertEquals('Test Company', $company->name);
-        $this->assertEquals('test.com', $company->domain);
-        $this->assertEquals('Test Description', $company->description);
-        $this->assertEquals('https://example.com/logo.png', $company->logo_url);
-        $this->assertEquals('https://test.com', $company->website_url);
+        $this->assertEquals($companyName, $company->name);
+        $this->assertEquals($domain, $company->domain);
+        $this->assertEquals($description, $company->description);
+        $this->assertEquals($logoUrl, $company->logo_url);
+        $this->assertEquals($websiteUrl, $company->website_url);
         $this->assertTrue($company->is_active);
     }
 
     public function test_company_name_is_required(): void
     {
         $this->expectException(\Illuminate\Database\QueryException::class);
-        
+
         Company::create([
-            'domain' => 'test.com',
+            'domain' => $this->faker()->domainName,
         ]);
     }
 
     public function test_company_domain_is_required(): void
     {
         $this->expectException(\Illuminate\Database\QueryException::class);
-        
+
         Company::create([
-            'name' => 'Test Company',
+            'name' => $this->faker()->company,
         ]);
     }
 
     public function test_company_domain_must_be_unique(): void
     {
+        $faker = $this->faker();
+        $domain = $faker->domainName;
+
         Company::create([
-            'name' => 'Test Company 1',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $domain,
         ]);
 
         $this->expectException(\Illuminate\Database\QueryException::class);
-        
+
         Company::create([
-            'name' => 'Test Company 2',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $domain,
         ]);
     }
 
     public function test_company_is_active_defaults_to_true(): void
     {
+        $faker = $this->faker();
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $faker->domainName,
         ]);
 
         $this->assertTrue($company->is_active);
@@ -75,9 +86,10 @@ class CompanyTest extends TestCase
 
     public function test_company_can_be_inactive(): void
     {
+        $faker = $this->faker();
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $faker->domainName,
             'is_active' => false,
         ]);
 
@@ -86,9 +98,10 @@ class CompanyTest extends TestCase
 
     public function test_company_optional_fields_can_be_null(): void
     {
+        $faker = $this->faker();
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $faker->domainName,
             'description' => null,
             'logo_url' => null,
             'website_url' => null,
@@ -101,7 +114,7 @@ class CompanyTest extends TestCase
 
     public function test_company_fillable_attributes(): void
     {
-        $company = new Company();
+        $company = new Company;
         $fillable = $company->getFillable();
 
         $this->assertEquals([
@@ -116,9 +129,10 @@ class CompanyTest extends TestCase
 
     public function test_company_casts_is_active_to_boolean(): void
     {
+        $faker = $this->faker();
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $faker->domainName,
             'is_active' => '1',
         ]);
 
@@ -128,9 +142,10 @@ class CompanyTest extends TestCase
 
     public function test_company_has_timestamps(): void
     {
+        $faker = $this->faker();
         $company = Company::create([
-            'name' => 'Test Company',
-            'domain' => 'test.com',
+            'name' => $faker->company,
+            'domain' => $faker->domainName,
         ]);
 
         $this->assertNotNull($company->created_at);


### PR DESCRIPTION
## 概要
テストの際により自然な日本語データを生成するため、日本語化したFakerを導入し、CompanyTestで使用するようにしました。

## 変更内容
- `tests/TestCase.php` に日本語化Fakerメソッドを追加
- `tests/Unit/CompanyTest.php` でFakerを使用するように更新
- `docs/wiki/開発フロー.md` に日本語化Fakerの使用方法を追記

## テスト結果
- 全テストが正常に通過
- コードスタイルチェックが通過

## 関連Issue
Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)