### PR TITLE
feat: Company モデルクラスの機能強化とテスト追加 #13

### DIFF
--- a/app/Models/Company.php
+++ b/app/Models/Company.php
@@ -25,4 +25,9 @@ class Company extends Model
     protected $attributes = [
         'is_active' => true,
     ];
+
+    public function scopeActive($query)
+    {
+        return $query->where('is_active', true);
+    }
 }

--- a/tests/Unit/Models/CompanyTest.php
+++ b/tests/Unit/Models/CompanyTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Company;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompanyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_基本的なモデル作成ができる()
+    {
+        $company = Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $this->faker()->domainName(),
+            'description' => $this->faker()->text(200),
+            'logo_url' => $this->faker()->imageUrl(),
+            'website_url' => $this->faker()->url(),
+        ]);
+
+        $this->assertInstanceOf(Company::class, $company);
+        $this->assertTrue($company->exists);
+    }
+
+    public function test_必須フィールドの検証()
+    {
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        Company::create([]);
+    }
+
+    public function test_domain_unique制約のテスト()
+    {
+        $domain = $this->faker()->domainName();
+
+        Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $domain,
+        ]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $domain,
+        ]);
+    }
+
+    public function test_デフォルト値の動作確認()
+    {
+        $company = Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $this->faker()->domainName(),
+        ]);
+
+        $this->assertTrue($company->is_active);
+    }
+
+    public function test_fillable属性の確認()
+    {
+        $company = new Company;
+        $fillable = $company->getFillable();
+
+        $expected = [
+            'name',
+            'domain',
+            'description',
+            'logo_url',
+            'website_url',
+            'is_active',
+        ];
+
+        $this->assertEquals($expected, $fillable);
+    }
+
+    public function test_型変換の確認()
+    {
+        $company = Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $this->faker()->domainName(),
+            'is_active' => '1',
+        ]);
+
+        $this->assertIsBool($company->is_active);
+        $this->assertTrue($company->is_active);
+
+        $company->is_active = false;
+        $this->assertIsBool($company->is_active);
+        $this->assertFalse($company->is_active);
+    }
+
+    public function test_タイムスタンプの確認()
+    {
+        $company = Company::create([
+            'name' => $this->faker()->company(),
+            'domain' => $this->faker()->domainName(),
+        ]);
+
+        $this->assertNotNull($company->created_at);
+        $this->assertNotNull($company->updated_at);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $company->created_at);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $company->updated_at);
+    }
+
+    public function test_activeスコープの動作確認()
+    {
+        Company::create([
+            'name' => 'Active Company',
+            'domain' => 'active.example.com',
+            'is_active' => true,
+        ]);
+
+        Company::create([
+            'name' => 'Inactive Company',
+            'domain' => 'inactive.example.com',
+            'is_active' => false,
+        ]);
+
+        $activeCompanies = Company::active()->get();
+        $this->assertCount(1, $activeCompanies);
+        $this->assertEquals('Active Company', $activeCompanies->first()->name);
+    }
+
+    public function test_mass_assignment_protection()
+    {
+        $data = [
+            'name' => $this->faker()->company(),
+            'domain' => $this->faker()->domainName(),
+            'created_at' => now()->subDays(10),
+        ];
+
+        $company = Company::create($data);
+
+        $this->assertNotEquals($data['created_at'], $company->created_at);
+    }
+}


### PR DESCRIPTION
## 概要
issue #13 に対応して、Companyモデルクラスの機能強化とテストを実装しました。

## 実装内容
- ✅ **activeスコープの追加**: アクティブな企業のみを取得するスコープを追加
- ✅ **包括的なユニットテスト作成**: 9つのテストケースで以下を検証
  - 基本的なモデル作成テスト
  - 必須フィールドの検証テスト
  - UNIQUE制約（domain）のテスト
  - デフォルト値の動作確認テスト
  - fillable属性の確認テスト
  - 型変換（boolean cast）の確認テスト
  - タイムスタンプの確認テスト
  - activeスコープの動作確認テスト
  - Mass Assignment Protection のテスト

## テスト結果
- ✅ 9テスト全て通過 (17アサーション)
- ✅ コードスタイルチェック通過 (pint)
- ✅ 静的解析チェック通過 (phpstan)

## 関連するissue
Closes #13

## 注意事項
- リレーション定義は他のモデルクラス（Article, CompanyInfluenceScore等）が作成された時点で追加予定
- データベース設計書の要件に従って実装済み

🤖 Generated with [Claude Code](https://claude.ai/code)