### PR TITLE
feat: Article テーブルのMigration作成 #12

### DIFF
--- a/database/migrations/2025_07_05_122604_create_articles_table.php
+++ b/database/migrations/2025_07_05_122604_create_articles_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('platform_id')->constrained('platforms');
+            $table->foreignId('company_id')->constrained('companies');
+            $table->string('title', 500);
+            $table->string('url', 1000)->unique();
+            $table->string('author_name', 255)->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->integer('bookmark_count')->default(0);
+            $table->timestamp('scraped_at');
+            $table->timestamps();
+            
+            // インデックス作成
+            $table->index(['company_id', 'published_at'], 'idx_articles_company_published');
+            $table->index(['platform_id', 'scraped_at'], 'idx_articles_platform_scraped');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('articles');
+    }
+};


### PR DESCRIPTION
## 概要
各プラットフォームから取得した記事情報を保存するArticleテーブルのMigrationファイルを作成しました。

## 実装内容
- `articles` テーブルのMigration作成
- 外部キー制約の設定
- 必要なインデックス設定

## テーブル構造
- `id`: AUTO_INCREMENT PRIMARY KEY
- `platform_id`: BIGINT NOT NULL (外部キー: platforms.id)
- `company_id`: BIGINT NOT NULL (外部キー: companies.id)
- `title`: VARCHAR(500) NOT NULL
- `url`: VARCHAR(1000) NOT NULL UNIQUE
- `author_name`: VARCHAR(255) NULL
- `published_at`: TIMESTAMP NULL
- `bookmark_count`: INTEGER NOT NULL DEFAULT 0
- `scraped_at`: TIMESTAMP NOT NULL
- `created_at`, `updated_at`: TIMESTAMP

## インデックス設定
- `idx_articles_company_published` (company_id, published_at)
- `idx_articles_platform_scraped` (platform_id, scraped_at)

## テスト結果
- ✅ 外部キー制約が適切に設定されている
- ✅ インデックスが適切に作成されている
- ✅ `php artisan migrate` でエラーなく実行完了

## 関連issue
Closes #12

🤖 Generated with [Claude Code](https://claude.ai/code)