### PR TITLE
feat: 基本データのSeeder作成 #16

### DIFF
--- a/database/seeders/CompanySeeder.php
+++ b/database/seeders/CompanySeeder.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Company;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class CompanySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $faker = fake('ja_JP');
+        
+        $realCompanies = [
+            [
+                'name' => $faker->company(),
+                'domain' => $faker->domainName(),
+                'description' => $faker->realText(100),
+                'website_url' => $faker->url(),
+                'is_active' => $faker->boolean(95),
+            ],
+            [
+                'name' => $faker->company(),
+                'domain' => $faker->unique()->domainName(),
+                'description' => $faker->realText(120),
+                'website_url' => $faker->url(),
+                'is_active' => $faker->boolean(95),
+            ],
+            [
+                'name' => $faker->company(),
+                'domain' => $faker->unique()->domainName(),
+                'description' => $faker->realText(80),
+                'website_url' => $faker->url(),
+                'is_active' => $faker->boolean(95),
+            ],
+            [
+                'name' => $faker->company(),
+                'domain' => $faker->unique()->domainName(),
+                'description' => $faker->realText(150),
+                'website_url' => $faker->url(),
+                'is_active' => $faker->boolean(95),
+            ],
+            [
+                'name' => $faker->company(),
+                'domain' => $faker->unique()->domainName(),
+                'description' => $faker->realText(90),
+                'website_url' => $faker->url(),
+                'is_active' => $faker->boolean(95),
+            ],
+        ];
+
+        foreach ($realCompanies as $company) {
+            Company::firstOrCreate(
+                ['domain' => $company['domain']],
+                $company
+            );
+        }
+
+        for ($i = 0; $i < 20; $i++) {
+            $companyName = $faker->company();
+            $domain = $faker->unique()->domainName();
+            
+            Company::firstOrCreate(
+                ['domain' => $domain],
+                [
+                    'name' => $companyName,
+                    'domain' => $domain,
+                    'description' => $faker->realText($faker->numberBetween(50, 200)),
+                    'website_url' => $faker->url(),
+                    'is_active' => $faker->boolean(85),
+                ]
+            );
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -13,11 +13,16 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call([
+            PlatformSeeder::class,
+            CompanySeeder::class,
+        ]);
 
+        $faker = fake('ja_JP');
+        
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => $faker->name(),
+            'email' => $faker->unique()->safeEmail(),
         ]);
     }
 }

--- a/database/seeders/PlatformSeeder.php
+++ b/database/seeders/PlatformSeeder.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Platform;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class PlatformSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $platforms = [
+            [
+                'name' => 'はてなブックマーク',
+                'base_url' => 'https://b.hatena.ne.jp/hotentry/it',
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Qiita',
+                'base_url' => 'https://qiita.com/trend',
+                'is_active' => true,
+            ],
+            [
+                'name' => 'Zenn',
+                'base_url' => 'https://zenn.dev/',
+                'is_active' => true,
+            ],
+        ];
+
+        foreach ($platforms as $platform) {
+            Platform::firstOrCreate(
+                ['name' => $platform['name']],
+                $platform
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 概要
開発・テスト用の基本データを投入するSeederを作成しました。

## 実装内容
- `PlatformSeeder` の作成
- `CompanySeeder` の作成
- `DatabaseSeeder` の更新

## 投入データ

### Platform データ
- **はてなブックマーク**: `https://b.hatena.ne.jp/hotentry/it` (ITカテゴリのホットエントリー)
- **Qiita**: `https://qiita.com/trend` (トレンド記事)
- **Zenn**: `https://zenn.dev/` (Techカテゴリ)

### Company データ
- **日本語Faker使用**: `fake('ja_JP')` で日本語企業名・説明文を生成
- **25社のテストデータ**: ランダムな企業情報を生成
- **リアルなデータ**: ドメイン名、ウェブサイトURL、説明文など

### User データ
- **日本語Faker使用**: 日本語名とランダムメールアドレス

## Faker使用による利点
- **動的なテストデータ**: 毎回異なるデータが生成される
- **日本語対応**: 日本のプロジェクトに適したテストデータ
- **現実的なデータ**: より実際のデータに近い内容

## テスト結果
- ✅ `php artisan db:seed` でエラーなく実行完了
- ✅ 期待されるデータが正しく投入されている
- ✅ Platform: 3件、Company: 25件、User: 1件

## 関連issue
Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)