### PR TITLE
feat: Qiita スクレイピング機能の実装 #19

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -15,8 +15,11 @@ class Article extends Model
         'domain',
         'platform',
         'author_name',
+        'author',
+        'author_url',
         'published_at',
         'bookmark_count',
+        'likes_count',
         'scraped_at',
     ];
 
@@ -24,6 +27,7 @@ class Article extends Model
         'published_at' => 'datetime',
         'scraped_at' => 'datetime',
         'bookmark_count' => 'integer',
+        'likes_count' => 'integer',
     ];
 
     public function company(): BelongsTo

--- a/app/Services/QiitaScraper.php
+++ b/app/Services/QiitaScraper.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Article;
+use App\Models\Company;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\DomCrawler\Crawler;
+
+class QiitaScraper extends BaseScraper
+{
+    protected string $baseUrl = 'https://qiita.com';
+
+    protected string $trendUrl = 'https://qiita.com/trend';
+
+    protected int $requestsPerMinute = 20;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setHeaders([
+            'Accept' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
+            'Accept-Language' => 'ja,en-US;q=0.5,en;q=0.3',
+            'Cache-Control' => 'no-cache',
+            'Pragma' => 'no-cache',
+        ]);
+    }
+
+    public function scrapeTrendingArticles(): array
+    {
+        Log::info('Qiitaトレンド記事のスクレイピングを開始');
+
+        $articles = $this->scrape($this->trendUrl);
+
+        Log::info('Qiitaスクレイピング完了', [
+            'articles_count' => count($articles),
+        ]);
+
+        return $articles;
+    }
+
+    protected function parseResponse(Response $response): array
+    {
+        $html = $response->body();
+        $crawler = new Crawler($html);
+        $articles = [];
+
+        $crawler->filter('article[data-hyperapp-app="Trend"]')->each(function (Crawler $node) use (&$articles) {
+            try {
+                $title = $this->extractTitle($node);
+                $url = $this->extractUrl($node);
+                $likesCount = $this->extractLikesCount($node);
+                $author = $this->extractAuthor($node);
+                $authorUrl = $this->extractAuthorUrl($node);
+                $publishedAt = $this->extractPublishedAt($node);
+
+                if ($title && $url) {
+                    $articles[] = [
+                        'title' => $title,
+                        'url' => $url,
+                        'likes_count' => $likesCount,
+                        'author' => $author,
+                        'author_url' => $authorUrl,
+                        'published_at' => $publishedAt,
+                        'scraped_at' => now(),
+                        'platform' => 'qiita',
+                    ];
+                }
+            } catch (\Exception $e) {
+                Log::warning('Qiita記事の解析中にエラー', [
+                    'error' => $e->getMessage(),
+                    'html' => $node->html(),
+                ]);
+            }
+        });
+
+        return $articles;
+    }
+
+    protected function extractTitle(Crawler $node): ?string
+    {
+        try {
+            $titleElement = $node->filter('h2 a');
+            if ($titleElement->count() > 0) {
+                return trim($titleElement->text());
+            }
+        } catch (\Exception $e) {
+            Log::debug('タイトル抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return null;
+    }
+
+    protected function extractUrl(Crawler $node): ?string
+    {
+        try {
+            $linkElement = $node->filter('h2 a');
+            if ($linkElement->count() > 0) {
+                $href = $linkElement->attr('href');
+
+                return $href ? $this->baseUrl.$href : null;
+            }
+        } catch (\Exception $e) {
+            Log::debug('URL抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return null;
+    }
+
+    protected function extractLikesCount(Crawler $node): int
+    {
+        try {
+            $likesElement = $node->filter('[data-testid="like-count"]');
+            if ($likesElement->count() > 0) {
+                $likesText = $likesElement->text();
+
+                return (int) preg_replace('/[^0-9]/', '', $likesText);
+            }
+        } catch (\Exception $e) {
+            Log::debug('いいね数抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return 0;
+    }
+
+    protected function extractAuthor(Crawler $node): ?string
+    {
+        try {
+            $authorElement = $node->filter('[data-hyperapp-app="UserIcon"] a');
+            if ($authorElement->count() > 0) {
+                return trim($authorElement->attr('href') ?? '');
+            }
+        } catch (\Exception $e) {
+            Log::debug('著者名抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return null;
+    }
+
+    protected function extractAuthorUrl(Crawler $node): ?string
+    {
+        try {
+            $authorElement = $node->filter('[data-hyperapp-app="UserIcon"] a');
+            if ($authorElement->count() > 0) {
+                $href = $authorElement->attr('href');
+
+                return $href ? $this->baseUrl.$href : null;
+            }
+        } catch (\Exception $e) {
+            Log::debug('著者URL抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return null;
+    }
+
+    protected function extractPublishedAt(Crawler $node): ?string
+    {
+        try {
+            $timeElement = $node->filter('time');
+            if ($timeElement->count() > 0) {
+                return $timeElement->attr('datetime');
+            }
+        } catch (\Exception $e) {
+            Log::debug('投稿日時抽出エラー', ['error' => $e->getMessage()]);
+        }
+
+        return null;
+    }
+
+    public function identifyCompanyAccount(?string $authorUrl): ?Company
+    {
+        if (! $authorUrl) {
+            return null;
+        }
+
+        $username = basename(parse_url($authorUrl, PHP_URL_PATH));
+
+        return Company::where('qiita_username', $username)->first();
+    }
+
+    public function normalizeAndSaveData(array $articles): array
+    {
+        $savedArticles = [];
+
+        foreach ($articles as $article) {
+            try {
+                $company = $this->identifyCompanyAccount($article['author_url']);
+
+                $savedArticle = Article::updateOrCreate(
+                    ['url' => $article['url']],
+                    [
+                        'title' => $article['title'],
+                        'company_id' => $company?->id,
+                        'likes_count' => $article['likes_count'],
+                        'author' => $article['author'],
+                        'author_url' => $article['author_url'],
+                        'published_at' => $article['published_at'],
+                        'platform' => $article['platform'],
+                        'scraped_at' => $article['scraped_at'],
+                    ]
+                );
+
+                $savedArticles[] = $savedArticle;
+
+                Log::debug('Qiita記事データを保存', [
+                    'title' => $article['title'],
+                    'author' => $article['author'],
+                    'company' => $company?->name,
+                    'likes_count' => $article['likes_count'],
+                ]);
+
+            } catch (\Exception $e) {
+                Log::error('Qiita記事データ保存エラー', [
+                    'article' => $article,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        Log::info('Qiitaデータ正規化・保存完了', [
+            'total_articles' => count($articles),
+            'saved_articles' => count($savedArticles),
+        ]);
+
+        return $savedArticles;
+    }
+}

--- a/database/migrations/2025_07_05_204110_add_qiita_username_to_companies_table.php
+++ b/database/migrations/2025_07_05_204110_add_qiita_username_to_companies_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->string('qiita_username')->nullable()->comment('Qiitaユーザー名');
+            $table->index('qiita_username');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('companies', function (Blueprint $table) {
+            $table->dropIndex(['qiita_username']);
+            $table->dropColumn('qiita_username');
+        });
+    }
+};

--- a/database/migrations/2025_07_05_204208_add_qiita_fields_to_articles_table.php
+++ b/database/migrations/2025_07_05_204208_add_qiita_fields_to_articles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->integer('likes_count')->default(0)->after('bookmark_count')->comment('いいね数（Qiita用）');
+            $table->string('author')->nullable()->after('author_name')->comment('投稿者情報');
+            $table->string('author_url', 500)->nullable()->after('author')->comment('投稿者URL');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn(['likes_count', 'author', 'author_url']);
+        });
+    }
+};

--- a/tests/Unit/QiitaScraperTest.php
+++ b/tests/Unit/QiitaScraperTest.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Company;
+use App\Services\QiitaScraper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class QiitaScraperTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private QiitaScraper $scraper;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->scraper = new QiitaScraper;
+    }
+
+    public function test_scraper_initialization()
+    {
+        $this->assertInstanceOf(QiitaScraper::class, $this->scraper);
+
+        $reflection = new \ReflectionClass($this->scraper);
+        $property = $reflection->getProperty('requestsPerMinute');
+        $property->setAccessible(true);
+        $this->assertEquals(20, $property->getValue($this->scraper));
+    }
+
+    public function test_parse_qiita_trend_html()
+    {
+        $mockHtml = $this->getMockQiitaHtml();
+
+        Http::fake([
+            'qiita.com/*' => Http::response($mockHtml, 200),
+        ]);
+
+        $result = $this->scraper->scrapeTrendingArticles();
+
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+
+        $this->assertEquals('Reactの新機能について', $result[0]['title']);
+        $this->assertEquals('https://qiita.com/items/12345', $result[0]['url']);
+        $this->assertEquals(150, $result[0]['likes_count']);
+        $this->assertEquals('/user1', $result[0]['author']);
+        $this->assertEquals('https://qiita.com/user1', $result[0]['author_url']);
+        $this->assertEquals('qiita', $result[0]['platform']);
+    }
+
+    public function test_identify_company_account()
+    {
+        $company = Company::factory()->create([
+            'qiita_username' => 'company_user',
+            'name' => 'Test Company',
+        ]);
+
+        $result = $this->scraper->identifyCompanyAccount('https://qiita.com/company_user');
+
+        $this->assertNotNull($result);
+        $this->assertEquals('Test Company', $result->name);
+    }
+
+    public function test_identify_company_account_not_found()
+    {
+        $result = $this->scraper->identifyCompanyAccount('https://qiita.com/unknown_user');
+
+        $this->assertNull($result);
+    }
+
+    public function test_identify_company_account_with_null_url()
+    {
+        $result = $this->scraper->identifyCompanyAccount(null);
+
+        $this->assertNull($result);
+    }
+
+    public function test_normalize_and_save_data()
+    {
+        $company = Company::factory()->create([
+            'qiita_username' => 'test_user',
+            'name' => 'Test Company',
+        ]);
+
+        $articles = [
+            [
+                'title' => 'テスト記事',
+                'url' => 'https://qiita.com/items/test123',
+                'likes_count' => 100,
+                'author' => '/test_user',
+                'author_url' => 'https://qiita.com/test_user',
+                'published_at' => '2024-01-01T10:00:00Z',
+                'platform' => 'qiita',
+                'scraped_at' => now(),
+            ],
+        ];
+
+        $result = $this->scraper->normalizeAndSaveData($articles);
+
+        $this->assertCount(1, $result);
+        $this->assertDatabaseHas('articles', [
+            'title' => 'テスト記事',
+            'url' => 'https://qiita.com/items/test123',
+            'company_id' => $company->id,
+            'likes_count' => 100,
+            'platform' => 'qiita',
+        ]);
+    }
+
+    public function test_extract_title()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractTitle');
+        $method->setAccessible(true);
+
+        $html = '<article><h2><a>テストタイトル</a></h2></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $title = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals('テストタイトル', $title);
+    }
+
+    public function test_extract_url()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractUrl');
+        $method->setAccessible(true);
+
+        $html = '<article><h2><a href="/items/12345">テストタイトル</a></h2></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $url = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals('https://qiita.com/items/12345', $url);
+    }
+
+    public function test_extract_likes_count()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractLikesCount');
+        $method->setAccessible(true);
+
+        $html = '<article><div data-testid="like-count">123</div></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $likesCount = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals(123, $likesCount);
+    }
+
+    public function test_extract_author()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractAuthor');
+        $method->setAccessible(true);
+
+        $html = '<article><div data-hyperapp-app="UserIcon"><a href="/user123">User</a></div></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $author = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals('/user123', $author);
+    }
+
+    public function test_extract_author_url()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractAuthorUrl');
+        $method->setAccessible(true);
+
+        $html = '<article><div data-hyperapp-app="UserIcon"><a href="/user123">User</a></div></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $authorUrl = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals('https://qiita.com/user123', $authorUrl);
+    }
+
+    public function test_extract_published_at()
+    {
+        $reflection = new \ReflectionClass($this->scraper);
+        $method = $reflection->getMethod('extractPublishedAt');
+        $method->setAccessible(true);
+
+        $html = '<article><time datetime="2024-01-01T10:00:00Z"></time></article>';
+        $crawler = new \Symfony\Component\DomCrawler\Crawler($html);
+
+        $publishedAt = $method->invokeArgs($this->scraper, [$crawler]);
+        $this->assertEquals('2024-01-01T10:00:00Z', $publishedAt);
+    }
+
+    public function test_handles_parsing_errors_gracefully()
+    {
+        $malformedHtml = '<html><body><div class="invalid">broken</div></body></html>';
+
+        Http::fake([
+            'qiita.com/*' => Http::response($malformedHtml, 200),
+        ]);
+
+        $result = $this->scraper->scrapeTrendingArticles();
+
+        $this->assertIsArray($result);
+        $this->assertEmpty($result);
+    }
+
+    public function test_handles_missing_elements_gracefully()
+    {
+        $incompleteHtml = '
+        <html>
+        <body>
+            <article data-hyperapp-app="Trend">
+                <h2><a href="/items/12345">タイトルのみ</a></h2>
+            </article>
+        </body>
+        </html>';
+
+        Http::fake([
+            'qiita.com/*' => Http::response($incompleteHtml, 200),
+        ]);
+
+        $result = $this->scraper->scrapeTrendingArticles();
+
+        $this->assertIsArray($result);
+        $this->assertCount(1, $result);
+        $this->assertEquals('タイトルのみ', $result[0]['title']);
+        $this->assertEquals(0, $result[0]['likes_count']);
+        $this->assertNull($result[0]['author']);
+    }
+
+    private function getMockQiitaHtml(): string
+    {
+        return '
+        <html>
+        <body>
+            <article data-hyperapp-app="Trend">
+                <h2>
+                    <a href="/items/12345">Reactの新機能について</a>
+                </h2>
+                <div data-testid="like-count">150</div>
+                <div data-hyperapp-app="UserIcon">
+                    <a href="/user1">ユーザー1</a>
+                </div>
+                <time datetime="2024-01-01T10:00:00Z"></time>
+            </article>
+            <article data-hyperapp-app="Trend">
+                <h2>
+                    <a href="/items/67890">Vue.jsのベストプラクティス</a>
+                </h2>
+                <div data-testid="like-count">80</div>
+                <div data-hyperapp-app="UserIcon">
+                    <a href="/user2">ユーザー2</a>
+                </div>
+                <time datetime="2024-01-02T15:30:00Z"></time>
+            </article>
+        </body>
+        </html>';
+    }
+}


### PR DESCRIPTION
## Summary
- QiitaScraperクラスを実装し、Qiitaトレンド記事のスクレイピング機能を追加
- 企業アカウントの識別・マッチング機能を実装
- 記事データの正規化・保存機能を実装
- 包括的なテストケース（14個）を実装
- 必要なデータベースmigrationを追加

## Test plan
- [x] QiitaScraperクラスが正常に初期化される
- [x] Qiitaトレンド記事を正しく解析できる
- [x] 企業アカウントの識別が機能する
- [x] 記事データが正しく保存される
- [x] エラーハンドリングが適切に動作する
- [x] 全てのテストが通ることを確認済み

🤖 Generated with [Claude Code](https://claude.ai/code)