### PR TITLE
feat: 分析・集計テーブルのMigration作成 #22

### DIFF
--- a/database/migrations/2025_07_06_085607_create_company_influence_scores_table.php
+++ b/database/migrations/2025_07_06_085607_create_company_influence_scores_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('company_influence_scores', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->string('period_type', 50);
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->decimal('total_score', 10, 2);
+            $table->integer('article_count')->default(0);
+            $table->integer('total_bookmarks')->default(0);
+            $table->timestamp('calculated_at');
+            $table->timestamps();
+            
+            $table->index(['company_id', 'period_type', 'period_start'], 'idx_influence_company_period');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('company_influence_scores');
+    }
+};

--- a/database/migrations/2025_07_06_085608_create_company_ranking_histories_table.php
+++ b/database/migrations/2025_07_06_085608_create_company_ranking_histories_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('company_ranking_histories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->string('ranking_period', 10);
+            $table->integer('rank_position');
+            $table->integer('rank_change')->default(0);
+            $table->decimal('total_score', 10, 2);
+            $table->timestamp('calculated_at');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('company_ranking_histories');
+    }
+};

--- a/database/migrations/2025_07_06_085608_create_company_rankings_table.php
+++ b/database/migrations/2025_07_06_085608_create_company_rankings_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('company_rankings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('company_id')->constrained()->onDelete('cascade');
+            $table->string('ranking_period', 10);
+            $table->integer('rank_position');
+            $table->decimal('total_score', 10, 2);
+            $table->integer('article_count')->default(0);
+            $table->integer('total_bookmarks')->default(0);
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->timestamp('calculated_at');
+            $table->timestamps();
+            
+            $table->index(['ranking_period', 'rank_position'], 'idx_rankings_period_rank');
+            $table->index(['company_id', 'ranking_period'], 'idx_rankings_company_period');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('company_rankings');
+    }
+};

--- a/database/migrations/2025_07_06_085608_create_scraping_logs_table.php
+++ b/database/migrations/2025_07_06_085608_create_scraping_logs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scraping_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('platform_id')->constrained()->onDelete('cascade');
+            $table->timestamp('started_at');
+            $table->timestamp('finished_at')->nullable();
+            $table->string('status', 50);
+            $table->integer('articles_scraped')->default(0);
+            $table->integer('errors_count')->default(0);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scraping_logs');
+    }
+};

--- a/docs/wiki/データベース設計.md
+++ b/docs/wiki/データベース設計.md
@@ -282,13 +282,13 @@ CREATE INDEX idx_influence_company_period ON company_influence_scores(company_id
 2. ✅ platforms
 3. ✅ articles
 
-### Phase 2: 分析・集計テーブル（🚧 今後実装予定）
-4. ⏳ company_influence_scores
-5. ⏳ company_rankings
-6. ⏳ company_ranking_histories
+### Phase 2: 分析・集計テーブル（✅ 実装完了）
+4. ✅ company_influence_scores
+5. ✅ company_rankings
+6. ✅ company_ranking_histories
 
-### Phase 3: 運用テーブル（🚧 今後実装予定）
-7. ⏳ scraping_logs
+### Phase 3: 運用テーブル（✅ 実装完了）
+7. ✅ scraping_logs
 
 ## ランキング機能
 


### PR DESCRIPTION
## 概要

企業影響力分析とランキング機能に必要な4つのテーブルのMigrationを作成しました。

## 実装内容

### 新規作成テーブル
- `company_influence_scores`: 企業の影響力スコア（期間別）
- `company_rankings`: 企業ランキング（7つの期間）
- `company_ranking_histories`: 企業ランキング履歴
- `scraping_logs`: スクレイピング実行ログ

### インデックス設定
- `company_rankings`: 期間別・順位別の検索最適化
- `company_influence_scores`: 企業・期間別の検索最適化

### ドキュメント更新
- データベース設計書の実装ステータス更新（Phase 2, 3完了）

## テストコマンド

```bash
php artisan migrate
```

## 完了条件
- [x] 4つのテーブルのMigrationが作成されている
- [x] 外部キー制約が適切に設定されている
- [x] インデックスが適切に作成されている
- [x] `php artisan migrate` でエラーが発生しない
- [x] データベース設計書が更新されている

## 関連Issue

Closes #22

🤖 Generated with [Claude Code](https://claude.ai/code)