### PR TITLE
feat: 企業影響力スコア計算バッチ処理の実装 #23

### DIFF
--- a/app/Jobs/CalculateCompanyInfluenceScoresJob.php
+++ b/app/Jobs/CalculateCompanyInfluenceScoresJob.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\CompanyInfluenceScoreService;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class CalculateCompanyInfluenceScoresJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Job実行タイムアウト（秒）
+     */
+    public int $timeout = 300;
+
+    /**
+     * 最大試行回数
+     */
+    public int $tries = 3;
+
+    /**
+     * 基準日付
+     */
+    private ?Carbon $referenceDate;
+
+    /**
+     * 処理対象期間タイプ
+     */
+    private ?string $periodType;
+
+    /**
+     * コンストラクタ
+     */
+    public function __construct(?Carbon $referenceDate = null, ?string $periodType = null)
+    {
+        $this->referenceDate = $referenceDate;
+        $this->periodType = $periodType;
+    }
+
+    /**
+     * Jobを実行
+     */
+    public function handle(CompanyInfluenceScoreService $scoreService): void
+    {
+        $startTime = microtime(true);
+
+        try {
+            Log::info('Company influence scores calculation job started', [
+                'reference_date' => $this->referenceDate?->toDateString(),
+                'period_type' => $this->periodType,
+            ]);
+
+            if ($this->periodType) {
+                // 特定の期間タイプのみ処理
+                $this->calculateSpecificPeriod($scoreService);
+            } else {
+                // 全期間タイプを処理
+                $this->calculateAllPeriods($scoreService);
+            }
+
+            $executionTime = microtime(true) - $startTime;
+
+            Log::info('Company influence scores calculation job completed', [
+                'execution_time' => round($executionTime, 2),
+                'reference_date' => $this->referenceDate?->toDateString(),
+                'period_type' => $this->periodType,
+            ]);
+
+        } catch (\Exception $e) {
+            $executionTime = microtime(true) - $startTime;
+
+            Log::error('Company influence scores calculation job failed', [
+                'error' => $e->getMessage(),
+                'execution_time' => round($executionTime, 2),
+                'reference_date' => $this->referenceDate?->toDateString(),
+                'period_type' => $this->periodType,
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * 特定の期間タイプのスコアを計算
+     */
+    private function calculateSpecificPeriod(CompanyInfluenceScoreService $scoreService): void
+    {
+        $referenceDate = $this->referenceDate ?? now();
+        $periodDays = $this->getPeriodDays($this->periodType);
+
+        $periodEnd = $referenceDate->copy();
+        $periodStart = $referenceDate->copy()->subDays($periodDays);
+
+        $scores = $scoreService->calculateAllCompaniesScore(
+            $this->periodType,
+            $periodStart,
+            $periodEnd
+        );
+
+        Log::info('Specific period calculation completed', [
+            'period_type' => $this->periodType,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'companies_processed' => count($scores),
+        ]);
+    }
+
+    /**
+     * 全期間タイプのスコアを計算
+     */
+    private function calculateAllPeriods(CompanyInfluenceScoreService $scoreService): void
+    {
+        $results = $scoreService->calculateScoresByPeriod($this->referenceDate);
+
+        $totalCompanies = 0;
+        foreach ($results as $periodType => $scores) {
+            $totalCompanies += count($scores);
+        }
+
+        Log::info('All periods calculation completed', [
+            'periods_calculated' => count($results),
+            'total_companies_processed' => $totalCompanies,
+        ]);
+    }
+
+    /**
+     * 期間タイプに対応する日数を取得
+     */
+    private function getPeriodDays(string $periodType): int
+    {
+        return match ($periodType) {
+            'daily' => 1,
+            'weekly' => 7,
+            'monthly' => 30,
+            default => throw new \InvalidArgumentException("Invalid period type: {$periodType}"),
+        };
+    }
+
+    /**
+     * Job失敗時の処理
+     */
+    public function failed(\Throwable $exception): void
+    {
+        Log::error('Company influence scores calculation job failed permanently', [
+            'exception' => $exception->getMessage(),
+            'trace' => $exception->getTraceAsString(),
+            'reference_date' => $this->referenceDate?->toDateString(),
+            'period_type' => $this->periodType,
+        ]);
+    }
+
+    /**
+     * 一意のJob識別子を生成
+     */
+    public function uniqueId(): string
+    {
+        $dateStr = $this->referenceDate ? $this->referenceDate->toDateString() : 'now';
+        $periodStr = $this->periodType ?? 'all';
+
+        return "company_influence_scores_{$dateStr}_{$periodStr}";
+    }
+}

--- a/app/Models/CompanyInfluenceScore.php
+++ b/app/Models/CompanyInfluenceScore.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CompanyInfluenceScore extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'company_id',
+        'period_type',
+        'period_start',
+        'period_end',
+        'total_score',
+        'article_count',
+        'total_bookmarks',
+        'calculated_at',
+    ];
+
+    protected $casts = [
+        'period_start' => 'date',
+        'period_end' => 'date',
+        'total_score' => 'decimal:2',
+        'article_count' => 'integer',
+        'total_bookmarks' => 'integer',
+        'calculated_at' => 'datetime',
+    ];
+
+    /**
+     * 企業とのリレーション
+     */
+    public function company(): BelongsTo
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    /**
+     * 期間タイプでフィルター
+     */
+    public function scopePeriodType($query, string $periodType)
+    {
+        return $query->where('period_type', $periodType);
+    }
+
+    /**
+     * 期間範囲でフィルター
+     */
+    public function scopePeriodRange($query, $startDate, $endDate)
+    {
+        return $query->whereBetween('period_start', [$startDate, $endDate]);
+    }
+
+    /**
+     * スコア順でソート
+     */
+    public function scopeOrderByScore($query, string $direction = 'desc')
+    {
+        return $query->orderBy('total_score', $direction);
+    }
+
+    /**
+     * 計算日時順でソート
+     */
+    public function scopeOrderByCalculatedAt($query, string $direction = 'desc')
+    {
+        return $query->orderBy('calculated_at', $direction);
+    }
+
+    /**
+     * 最新の計算結果を取得
+     */
+    public function scopeLatest($query)
+    {
+        return $query->orderBy('calculated_at', 'desc');
+    }
+
+    /**
+     * 特定企業のスコアを取得
+     */
+    public function scopeForCompany($query, int $companyId)
+    {
+        return $query->where('company_id', $companyId);
+    }
+}

--- a/app/Services/CompanyInfluenceScoreService.php
+++ b/app/Services/CompanyInfluenceScoreService.php
@@ -1,0 +1,273 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Article;
+use App\Models\Company;
+use App\Models\CompanyInfluenceScore;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class CompanyInfluenceScoreService
+{
+    /**
+     * 重み付け設定
+     */
+    private const WEIGHTS = [
+        'article_base' => 1.0,
+        'bookmark_multiplier' => 0.1,
+        'likes_multiplier' => 0.05,
+        'platform_qiita' => 1.0,
+        'platform_zenn' => 1.0,
+        'platform_hatena' => 0.8,
+        'time_decay_factor' => 0.95,
+    ];
+
+    /**
+     * 期間タイプ定義
+     */
+    private const PERIOD_TYPES = [
+        'daily' => 1,
+        'weekly' => 7,
+        'monthly' => 30,
+    ];
+
+    /**
+     * 企業の影響力スコアを計算
+     */
+    public function calculateCompanyScore(Company $company, string $periodType, Carbon $periodStart, Carbon $periodEnd): float
+    {
+        $articles = $this->getArticlesForPeriod($company, $periodStart, $periodEnd);
+
+        if ($articles->isEmpty()) {
+            return 0.0;
+        }
+
+        $totalScore = 0.0;
+
+        foreach ($articles as $article) {
+            $score = $this->calculateArticleScore($article, $periodStart, $periodEnd);
+            $totalScore += $score;
+        }
+
+        Log::info('Company influence score calculated', [
+            'company_id' => $company->id,
+            'company_name' => $company->name,
+            'period_type' => $periodType,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'article_count' => $articles->count(),
+            'total_score' => $totalScore,
+        ]);
+
+        return round($totalScore, 2);
+    }
+
+    /**
+     * 記事の影響力スコアを計算
+     */
+    private function calculateArticleScore(Article $article, Carbon $periodStart, Carbon $periodEnd): float
+    {
+        // 基本スコア（記事の存在による基本点）
+        $baseScore = self::WEIGHTS['article_base'];
+
+        // ブックマーク数による重み付け
+        $bookmarkScore = $article->bookmark_count * self::WEIGHTS['bookmark_multiplier'];
+
+        // いいね数による重み付け
+        $likesScore = $article->likes_count * self::WEIGHTS['likes_multiplier'];
+
+        // プラットフォームによる重み付け
+        $platformWeight = $this->getPlatformWeight($article->platform);
+
+        // 時系列による重み付け（新しい記事ほど高スコア）
+        $timeWeight = $this->getTimeWeight($article->published_at, $periodStart, $periodEnd);
+
+        $score = ($baseScore + $bookmarkScore + $likesScore) * $platformWeight * $timeWeight;
+
+        return $score;
+    }
+
+    /**
+     * プラットフォームによる重み付けを取得
+     */
+    private function getPlatformWeight(string $platform): float
+    {
+        $platform = strtolower($platform);
+
+        return match ($platform) {
+            'qiita' => self::WEIGHTS['platform_qiita'],
+            'zenn' => self::WEIGHTS['platform_zenn'],
+            'hatena' => self::WEIGHTS['platform_hatena'],
+            default => 0.5,
+        };
+    }
+
+    /**
+     * 時系列による重み付けを取得
+     */
+    private function getTimeWeight(?Carbon $publishedAt, Carbon $periodStart, Carbon $periodEnd): float
+    {
+        if (!$publishedAt || $publishedAt->lt($periodStart) || $publishedAt->gt($periodEnd)) {
+            return 0.5; // 公開日が不明または期間外の場合は低い重み
+        }
+
+        $periodDays = $periodEnd->diffInDays($periodStart);
+        $daysSinceStart = $publishedAt->diffInDays($periodStart);
+
+        // 期間内での相対的な新しさを計算（0.0～1.0）
+        $relativeNewness = $periodDays > 0 ? (1.0 - ($daysSinceStart / $periodDays)) : 1.0;
+
+        // 時間減衰を適用
+        $decayFactor = self::WEIGHTS['time_decay_factor'];
+        $timeWeight = pow($decayFactor, $daysSinceStart);
+
+        return max(0.1, $timeWeight * (0.5 + $relativeNewness * 0.5));
+    }
+
+    /**
+     * 指定期間の記事を取得
+     */
+    private function getArticlesForPeriod(Company $company, Carbon $periodStart, Carbon $periodEnd)
+    {
+        return Article::where('company_id', $company->id)
+            ->whereBetween('published_at', [$periodStart, $periodEnd])
+            ->orWhere(function ($query) use ($company, $periodStart, $periodEnd) {
+                $query->where('company_id', $company->id)
+                    ->whereNull('published_at')
+                    ->whereBetween('scraped_at', [$periodStart, $periodEnd]);
+            })
+            ->get();
+    }
+
+    /**
+     * 企業の影響力スコアを保存
+     */
+    public function saveCompanyInfluenceScore(
+        Company $company,
+        string $periodType,
+        Carbon $periodStart,
+        Carbon $periodEnd,
+        float $totalScore
+    ): CompanyInfluenceScore {
+        $articles = $this->getArticlesForPeriod($company, $periodStart, $periodEnd);
+        $articleCount = $articles->count();
+        $totalBookmarks = $articles->sum('bookmark_count');
+
+        return CompanyInfluenceScore::updateOrCreate(
+            [
+                'company_id' => $company->id,
+                'period_type' => $periodType,
+                'period_start' => $periodStart->toDateString(),
+                'period_end' => $periodEnd->toDateString(),
+            ],
+            [
+                'total_score' => $totalScore,
+                'article_count' => $articleCount,
+                'total_bookmarks' => $totalBookmarks,
+                'calculated_at' => now(),
+            ]
+        );
+    }
+
+    /**
+     * 全企業の影響力スコアを一括計算
+     */
+    public function calculateAllCompaniesScore(string $periodType, Carbon $periodStart, Carbon $periodEnd): array
+    {
+        $companies = Company::where('is_active', true)->get();
+        $results = [];
+
+        foreach ($companies as $company) {
+            $score = $this->calculateCompanyScore($company, $periodType, $periodStart, $periodEnd);
+            
+            if ($score > 0) {
+                $influenceScore = $this->saveCompanyInfluenceScore(
+                    $company,
+                    $periodType,
+                    $periodStart,
+                    $periodEnd,
+                    $score
+                );
+                $results[] = $influenceScore;
+            }
+        }
+
+        Log::info('All companies influence scores calculated', [
+            'period_type' => $periodType,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'companies_processed' => count($results),
+        ]);
+
+        return $results;
+    }
+
+    /**
+     * 期間別スコア計算のヘルパーメソッド
+     */
+    public function calculateScoresByPeriod(Carbon $referenceDate = null): array
+    {
+        $referenceDate = $referenceDate ?? now();
+        $results = [];
+
+        foreach (self::PERIOD_TYPES as $periodType => $days) {
+            $periodEnd = $referenceDate->copy();
+            $periodStart = $referenceDate->copy()->subDays($days);
+
+            $scores = $this->calculateAllCompaniesScore($periodType, $periodStart, $periodEnd);
+            $results[$periodType] = $scores;
+        }
+
+        return $results;
+    }
+
+    /**
+     * 指定企業の期間別スコアを取得
+     */
+    public function getCompanyScoresByPeriod(Company $company, int $limit = 10): array
+    {
+        $scores = [];
+
+        foreach (self::PERIOD_TYPES as $periodType => $days) {
+            $scores[$periodType] = CompanyInfluenceScore::where('company_id', $company->id)
+                ->where('period_type', $periodType)
+                ->orderBy('calculated_at', 'desc')
+                ->limit($limit)
+                ->get()
+                ->toArray();
+        }
+
+        return $scores;
+    }
+
+    /**
+     * 企業スコアの統計情報を取得
+     */
+    public function getCompanyScoreStatistics(Company $company): array
+    {
+        $statistics = [];
+
+        foreach (self::PERIOD_TYPES as $periodType => $days) {
+            $stats = CompanyInfluenceScore::where('company_id', $company->id)
+                ->where('period_type', $periodType)
+                ->selectRaw('
+                    AVG(total_score) as avg_score,
+                    MAX(total_score) as max_score,
+                    MIN(total_score) as min_score,
+                    COUNT(*) as score_count
+                ')
+                ->first();
+
+            $statistics[$periodType] = [
+                'average_score' => round($stats->avg_score ?? 0, 2),
+                'max_score' => round($stats->max_score ?? 0, 2),
+                'min_score' => round($stats->min_score ?? 0, 2),
+                'score_count' => $stats->score_count ?? 0,
+            ];
+        }
+
+        return $statistics;
+    }
+}

--- a/docs/wiki/自動化スクリプト.md
+++ b/docs/wiki/自動化スクリプト.md
@@ -112,8 +112,136 @@ chmod +x scripts/check-wiki-with-claude.sh
 - JSON形式が正しいかチェック
 - Claude Codeの再起動を試行
 
+## 企業影響力スコア計算バッチ処理
+
+### 概要
+
+企業の技術コミュニティでの影響力を定量化するスコア計算を自動化するバッチ処理システムです。
+
+### 実装内容
+
+#### CompanyInfluenceScoreService
+
+企業の影響力スコア計算を担当するサービスクラスです。
+
+**主な機能:**
+- 企業の影響力スコア計算
+- 記事の影響力スコア計算
+- 期間別スコア計算
+- スコア統計情報の取得
+
+**スコア計算ロジック:**
+- 記事数の重み付け（基本スコア: 1.0）
+- ブックマーク数の重み付け（倍率: 0.1）
+- いいね数の重み付け（倍率: 0.05）
+- プラットフォーム別重み付け（Qiita: 1.0, Zenn: 1.0, はてな: 0.8）
+- 時系列による重み付け（新しい記事ほど高スコア）
+
+#### CalculateCompanyInfluenceScoresJob
+
+企業影響力スコア計算を非同期で実行するためのJobクラスです。
+
+**実行パターン:**
+```php
+// 全期間タイプのスコア計算
+CalculateCompanyInfluenceScoresJob::dispatch();
+
+// 特定期間のスコア計算
+CalculateCompanyInfluenceScoresJob::dispatch(now(), 'daily');
+
+// 特定日付基準のスコア計算
+CalculateCompanyInfluenceScoresJob::dispatch(Carbon::parse('2025-01-01'));
+```
+
+**対応期間タイプ:**
+- `daily`: 日次（1日）
+- `weekly`: 週次（7日）
+- `monthly`: 月次（30日）
+
+#### CompanyInfluenceScoreModel
+
+企業影響力スコアデータを管理するEloquentモデルです。
+
+**主な機能:**
+- 期間タイプでのフィルタリング
+- 期間範囲での検索
+- スコア順ソート
+- 企業別スコア取得
+
+### 使用方法
+
+#### 手動実行
+
+```php
+use App\Services\CompanyInfluenceScoreService;
+use App\Models\Company;
+use Carbon\Carbon;
+
+$scoreService = new CompanyInfluenceScoreService();
+
+// 特定企業のスコア計算
+$company = Company::find(1);
+$score = $scoreService->calculateCompanyScore(
+    $company,
+    'daily',
+    Carbon::now()->subDay(),
+    Carbon::now()
+);
+
+// 全企業のスコア計算
+$scores = $scoreService->calculateAllCompaniesScore(
+    'weekly',
+    Carbon::now()->subWeek(),
+    Carbon::now()
+);
+```
+
+#### バッチ処理実行
+
+```bash
+# Artisanコマンドでの実行
+php artisan queue:work
+
+# 直接Job実行
+php artisan tinker
+> App\Jobs\CalculateCompanyInfluenceScoresJob::dispatch();
+```
+
+### 設定
+
+**重み付け調整:**
+`CompanyInfluenceScoreService::WEIGHTS` 定数で各要素の重み付けを調整できます。
+
+**期間設定:**
+`CompanyInfluenceScoreService::PERIOD_TYPES` 定数で期間タイプの日数を設定できます。
+
+### 運用
+
+#### 定期実行設定
+
+Laravel Schedulerを使用して定期実行を設定できます：
+
+```php
+// app/Console/Kernel.php
+protected function schedule(Schedule $schedule)
+{
+    // 毎日深夜にスコア計算実行
+    $schedule->job(new CalculateCompanyInfluenceScoresJob())
+        ->daily()
+        ->at('02:00');
+}
+```
+
+#### 監視とログ
+
+- 実行ログは `storage/logs/laravel.log` に記録
+- Job失敗時は `failed_jobs` テーブルに記録
+- 処理時間と対象企業数を監視可能
+
 ## 関連ドキュメント
 
 - [開発フロー](開発フロー.md) - 開発フローにおけるスクリプトの位置づけ
 - [CI-CD](CI-CD.md) - wiki自動同期のCI/CD設定
 - [開発環境](開発環境.md) - Claude Codeの設定方法
+- [データベース設計](データベース設計.md) - 企業影響力スコア関連テーブル
+- [技術スタック](技術スタック.md) - Laravel Jobs、Queue設定


### PR DESCRIPTION
## 概要

企業の技術コミュニティでの影響力を定量化するスコア計算バッチ処理を実装しました。

## 実装内容

### 🔧 新規クラス作成

- **CompanyInfluenceScoreService**: 企業影響力スコア計算サービスクラス
- **CalculateCompanyInfluenceScoresJob**: 非同期バッチ処理用Jobクラス  
- **CompanyInfluenceScore**: 企業影響力スコアEloquentモデル

### 📊 スコア計算ロジック

- 記事数の重み付け（基本スコア: 1.0）
- ブックマーク数の重み付け（倍率: 0.1）
- いいね数の重み付け（倍率: 0.05）
- プラットフォーム別重み付け（Qiita: 1.0, Zenn: 1.0, はてな: 0.8）
- 時系列による重み付け（新しい記事ほど高スコア）

### ⏰ 期間別処理対応

- 日次（daily）: 1日
- 週次（weekly）: 7日  
- 月次（monthly）: 30日

### 📚 ドキュメント更新

- `docs/wiki/自動化スクリプト.md`に企業影響力スコア計算バッチ処理の詳細説明を追加

## 使用方法

```php
// 全期間タイプのスコア計算
CalculateCompanyInfluenceScoresJob::dispatch();

// 特定期間のスコア計算
CalculateCompanyInfluenceScoresJob::dispatch(now(), 'daily');
```

## テスト計画

- [ ] CompanyInfluenceScoreServiceの単体テスト作成
- [ ] CalculateCompanyInfluenceScoresJobの動作テスト
- [ ] スコア計算ロジックの検証
- [ ] パフォーマンステスト（大量データ処理）
- [ ] 期間別計算の正確性テスト

🤖 Generated with [Claude Code](https://claude.ai/code)