### PR TITLE
fix: ランキング履歴管理機能の改善とテスト追加 #25

### DIFF
--- a/app/Services/CompanyRankingHistoryService.php
+++ b/app/Services/CompanyRankingHistoryService.php
@@ -79,8 +79,7 @@ class CompanyRankingHistoryService
     {
         return DB::table('company_rankings')
             ->where('ranking_period', $periodType)
-            ->where('calculated_at', '<=', $calculatedAt)
-            ->orderBy('calculated_at', 'desc')
+            ->where('calculated_at', $calculatedAt)
             ->orderBy('rank_position')
             ->get()
             ->toArray();


### PR DESCRIPTION
## 概要
ランキング履歴管理機能の既存のバグを修正し、テストカバレッジを向上させました。

## 修正内容
### バグ修正
- `CompanyRankingHistoryService::getCurrentRankings` メソッドの修正
  - 複数の計算時刻のデータを取得していた問題を修正
  - 指定された計算時刻のデータのみを取得するように変更

### テスト追加
- 順位変動なしのケースのテスト
- 複数企業の順位変動のケースのテスト
- より包括的なテストカバレッジの実現

## テスト結果
```
✓ 11 passed (51 assertions)
```

## 関連issue
Closes #25

🤖 Generated with [Claude Code](https://claude.ai/code)