### PR TITLE
feat: htmlのtitleおよびheaderのtitleを.envのAPP_NAMEを参照するように修正

### DIFF
--- a/resources/js/components/Header.tsx
+++ b/resources/js/components/Header.tsx
@@ -8,7 +8,7 @@ const Header: React.FC = () => {
                 <div className="flex justify-between items-center h-16">
                     <div className="flex items-center">
                         <Link to="/" className="text-xl font-bold text-gray-900">
-                            企業影響力ダッシュボード
+                            {import.meta.env.VITE_APP_NAME || 'DevCorpTrends'}
                         </Link>
                     </div>
                     <nav className="hidden md:flex space-x-8">

--- a/resources/js/vite-env.d.ts
+++ b/resources/js/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_APP_NAME: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>React Test - 企業影響力ダッシュボード</title>
+    <title>{{ config('app.name') }}</title>
     
     @vite('resources/js/app.tsx')
 </head>


### PR DESCRIPTION
## 概要
htmlのtitleおよびheaderのtitleを、.envファイルにあるAPP_NAMEを参照するように変更しました。

## 変更内容
- `resources/views/app.blade.php`: HTMLのtitleをLaravelの`config('app.name')`を参照するように変更
- `resources/js/components/Header.tsx`: ヘッダーのタイトルを`VITE_APP_NAME`環境変数を参照するように変更  
- `resources/js/vite-env.d.ts`: Vite環境変数の型定義を追加

## テスト計画
- [ ] ブラウザのタイトルバーに「DevCorpTrends」が表示されることを確認
- [ ] ヘッダーのタイトルに「DevCorpTrends」が表示されることを確認
- [ ] .envのAPP_NAMEを変更して正しく反映されることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.ai/code)