### PR TITLE
feat: API仕様書のOpenAPI (Swagger) 化 - issue#67対応

### DIFF
--- a/app/Http/Controllers/Api/CompanyController.php
+++ b/app/Http/Controllers/Api/CompanyController.php
@@ -30,7 +30,53 @@ class CompanyController extends Controller
     }
 
     /**
-     * 企業詳細情報取得
+     * @OA\Get(
+     *     path="/api/companies/{company_id}",
+     *     tags={"企業詳細"},
+     *     summary="企業詳細情報取得",
+     *     description="企業の詳細情報を取得します。現在のランキング情報と最近の記事（最大5件）を含みます。",
+     *     @OA\Parameter(
+     *         name="company_id",
+     *         in="path",
+     *         required=true,
+     *         description="企業ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="企業詳細情報",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="integer", example=1),
+     *                 @OA\Property(property="name", type="string", example="Company A"),
+     *                 @OA\Property(property="domain", type="string", example="company-a.com"),
+     *                 @OA\Property(property="description", type="string", example="企業の説明文"),
+     *                 @OA\Property(property="logo_url", type="string", example="https://example.com/logo.png"),
+     *                 @OA\Property(property="website_url", type="string", example="https://company-a.com"),
+     *                 @OA\Property(property="is_active", type="boolean", example=true),
+     *                 @OA\Property(property="current_rankings", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="recent_articles", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="created_at", type="string", format="date-time"),
+     *                 @OA\Property(property="updated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業IDが無効です"),
+     *             @OA\Property(property="details", type="object")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="企業が見つかりません",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業が見つかりません")
+     *         )
+     *     )
+     * )
      */
     public function show(int $companyId): JsonResponse
     {
@@ -68,7 +114,72 @@ class CompanyController extends Controller
     }
 
     /**
-     * 企業の記事一覧取得
+     * @OA\Get(
+     *     path="/api/companies/{company_id}/articles",
+     *     tags={"企業詳細"},
+     *     summary="企業の記事一覧取得",
+     *     description="企業に関連する記事の一覧を取得します。",
+     *     @OA\Parameter(
+     *         name="company_id",
+     *         in="path",
+     *         required=true,
+     *         description="企業ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="page",
+     *         in="query",
+     *         description="ページ番号",
+     *         @OA\Schema(type="integer", default=1, example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="1ページあたりの件数（最大100）",
+     *         @OA\Schema(type="integer", default=20, maximum=100, example=20)
+     *     ),
+     *     @OA\Parameter(
+     *         name="days",
+     *         in="query",
+     *         description="過去何日分の記事を取得するか",
+     *         @OA\Schema(type="integer", default=30, example=30)
+     *     ),
+     *     @OA\Parameter(
+     *         name="min_bookmarks",
+     *         in="query",
+     *         description="最小ブックマーク数",
+     *         @OA\Schema(type="integer", default=0, example=0)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="記事一覧",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer"),
+     *                 @OA\Property(property="per_page", type="integer"),
+     *                 @OA\Property(property="total", type="integer"),
+     *                 @OA\Property(property="last_page", type="integer"),
+     *                 @OA\Property(property="company_id", type="integer"),
+     *                 @OA\Property(property="filters", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業IDが無効です")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="企業が見つかりません",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業が見つかりません")
+     *         )
+     *     )
+     * )
      */
     public function articles(Request $request, int $companyId): JsonResponse
     {
@@ -125,7 +236,65 @@ class CompanyController extends Controller
     }
 
     /**
-     * 企業の影響力スコア履歴取得
+     * @OA\Get(
+     *     path="/api/companies/{company_id}/scores",
+     *     tags={"企業詳細"},
+     *     summary="企業の影響力スコア履歴取得",
+     *     description="企業の影響力スコアの履歴データを取得します。",
+     *     @OA\Parameter(
+     *         name="company_id",
+     *         in="path",
+     *         required=true,
+     *         description="企業ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="query",
+     *         description="期間タイプ",
+     *         @OA\Schema(type="string", default="1d", example="1d")
+     *     ),
+     *     @OA\Parameter(
+     *         name="days",
+     *         in="query",
+     *         description="過去何日分のスコアを取得するか",
+     *         @OA\Schema(type="integer", default=30, example=30)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="スコア履歴",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="company_id", type="integer", example=1),
+     *                 @OA\Property(property="scores", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="date", type="string", format="date", example="2024-01-30"),
+     *                     @OA\Property(property="score", type="number", format="float", example=85.5),
+     *                     @OA\Property(property="rank_position", type="integer", example=5),
+     *                     @OA\Property(property="calculated_at", type="string", format="date-time")
+     *                 ))
+     *             ),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="period", type="string"),
+     *                 @OA\Property(property="days", type="integer"),
+     *                 @OA\Property(property="total", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業IDが無効です")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="企業が見つかりません",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業が見つかりません")
+     *         )
+     *     )
+     * )
      */
     public function scores(Request $request, int $companyId): JsonResponse
     {
@@ -171,7 +340,56 @@ class CompanyController extends Controller
     }
 
     /**
-     * 企業のランキング情報取得
+     * @OA\Get(
+     *     path="/api/companies/{company_id}/rankings",
+     *     tags={"企業詳細"},
+     *     summary="企業のランキング情報取得",
+     *     description="企業の各期間でのランキング情報を取得します。",
+     *     @OA\Parameter(
+     *         name="company_id",
+     *         in="path",
+     *         required=true,
+     *         description="企業ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="include_history",
+     *         in="query",
+     *         description="履歴を含める",
+     *         @OA\Schema(type="boolean", default=false, example=false)
+     *     ),
+     *     @OA\Parameter(
+     *         name="history_days",
+     *         in="query",
+     *         description="履歴取得日数",
+     *         @OA\Schema(type="integer", default=30, example=30)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="ランキング情報",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="company_id", type="integer", example=1),
+     *                 @OA\Property(property="rankings", type="object"),
+     *                 @OA\Property(property="history", type="array", @OA\Items(type="object"))
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業IDが無効です")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="企業が見つかりません",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="企業が見つかりません")
+     *         )
+     *     )
+     * )
      */
     public function rankings(Request $request, int $companyId): JsonResponse
     {

--- a/app/Http/Controllers/Api/CompanyRankingController.php
+++ b/app/Http/Controllers/Api/CompanyRankingController.php
@@ -29,7 +29,63 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 期間別ランキング取得
+     * @OA\Get(
+     *     path="/api/rankings/{period}",
+     *     tags={"企業ランキング"},
+     *     summary="期間別ランキング取得",
+     *     description="指定した期間の企業ランキングを取得します。",
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="path",
+     *         required=true,
+     *         description="期間タイプ (1w, 1m, 3m, 6m, 1y, 3y, all)",
+     *         @OA\Schema(type="string", enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}, example="1m")
+     *     ),
+     *     @OA\Parameter(
+     *         name="page",
+     *         in="query",
+     *         description="ページ番号",
+     *         @OA\Schema(type="integer", default=1, example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="per_page",
+     *         in="query",
+     *         description="1ページあたりの件数（最大100）",
+     *         @OA\Schema(type="integer", default=20, maximum=100, example=20)
+     *     ),
+     *     @OA\Parameter(
+     *         name="sort_by",
+     *         in="query",
+     *         description="ソート項目",
+     *         @OA\Schema(type="string", default="rank_position", example="rank_position")
+     *     ),
+     *     @OA\Parameter(
+     *         name="sort_order",
+     *         in="query",
+     *         description="ソート順",
+     *         @OA\Schema(type="string", enum={"asc", "desc"}, default="asc", example="asc")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="ランキングリスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="current_page", type="integer"),
+     *                 @OA\Property(property="per_page", type="integer"),
+     *                 @OA\Property(property="total", type="integer"),
+     *                 @OA\Property(property="last_page", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正な期間タイプ",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function index(Request $request, string $period): JsonResponse
     {
@@ -86,7 +142,45 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 上位N件のランキング取得
+     * @OA\Get(
+     *     path="/api/rankings/{period}/top/{limit}",
+     *     tags={"企業ランキング"},
+     *     summary="上位N件のランキング取得",
+     *     description="指定した期間の上位N件のランキングを取得します。",
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="path",
+     *         required=true,
+     *         description="期間タイプ",
+     *         @OA\Schema(type="string", enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}, example="1m")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="path",
+     *         required=true,
+     *         description="取得件数 (1-100)",
+     *         @OA\Schema(type="integer", minimum=1, maximum=100, example=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="上位ランキング",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object")),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="period", type="string"),
+     *                 @OA\Property(property="limit", type="integer"),
+     *                 @OA\Property(property="total", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なパラメータ",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function top(Request $request, string $period, int $limit): JsonResponse
     {
@@ -122,7 +216,49 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 特定企業のランキング取得
+     * @OA\Get(
+     *     path="/api/rankings/company/{company_id}",
+     *     tags={"企業ランキング"},
+     *     summary="特定企業のランキング取得",
+     *     description="特定企業の全期間ランキング情報を取得します。",
+     *     @OA\Parameter(
+     *         name="company_id",
+     *         in="path",
+     *         required=true,
+     *         description="企業ID",
+     *         @OA\Schema(type="integer", example=1)
+     *     ),
+     *     @OA\Parameter(
+     *         name="include_history",
+     *         in="query",
+     *         description="履歴を含める",
+     *         @OA\Schema(type="boolean", default=false, example=false)
+     *     ),
+     *     @OA\Parameter(
+     *         name="history_days",
+     *         in="query",
+     *         description="履歴取得日数",
+     *         @OA\Schema(type="integer", default=30, example=30)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="企業ランキング情報",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="company_id", type="integer"),
+     *                 @OA\Property(property="rankings", type="object"),
+     *                 @OA\Property(property="history", type="object")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正な企業ID",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function company(Request $request, int $companyId): JsonResponse
     {
@@ -181,7 +317,29 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * ランキング統計情報取得
+     * @OA\Get(
+     *     path="/api/rankings/statistics",
+     *     tags={"企業ランキング"},
+     *     summary="ランキング統計情報取得",
+     *     description="全期間のランキング統計情報を取得します。",
+     *     @OA\Response(
+     *         response=200,
+     *         description="統計情報",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="1m", type="object",
+     *                     @OA\Property(property="total_companies", type="integer", example=100),
+     *                     @OA\Property(property="average_score", type="number", format="float", example=50.25),
+     *                     @OA\Property(property="max_score", type="number", format="float", example=150.75),
+     *                     @OA\Property(property="min_score", type="number", format="float", example=5.10),
+     *                     @OA\Property(property="total_articles", type="integer", example=1000),
+     *                     @OA\Property(property="total_bookmarks", type="integer", example=50000),
+     *                     @OA\Property(property="last_calculated", type="string", format="date-time")
+     *                 )
+     *             )
+     *         )
+     *     )
+     * )
      */
     public function statistics(): JsonResponse
     {
@@ -197,7 +355,51 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 順位変動上位企業取得
+     * @OA\Get(
+     *     path="/api/rankings/{period}/risers",
+     *     tags={"企業ランキング"},
+     *     summary="順位上昇企業取得",
+     *     description="指定した期間で順位が上昇した企業を取得します。",
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="path",
+     *         required=true,
+     *         description="期間タイプ",
+     *         @OA\Schema(type="string", enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}, example="1m")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         description="取得件数（最大50）",
+     *         @OA\Schema(type="integer", default=10, maximum=50, example=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="順位上昇企業リスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="company_name", type="string", example="Rising Company"),
+     *                 @OA\Property(property="domain", type="string", example="rising.com"),
+     *                 @OA\Property(property="current_rank", type="integer", example=5),
+     *                 @OA\Property(property="previous_rank", type="integer", example=10),
+     *                 @OA\Property(property="rank_change", type="integer", example=5),
+     *                 @OA\Property(property="calculated_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="period", type="string"),
+     *                 @OA\Property(property="limit", type="integer"),
+     *                 @OA\Property(property="total", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正な期間タイプ",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function risers(Request $request, string $period): JsonResponse
     {
@@ -230,7 +432,51 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 順位変動下位企業取得
+     * @OA\Get(
+     *     path="/api/rankings/{period}/fallers",
+     *     tags={"企業ランキング"},
+     *     summary="順位下降企業取得",
+     *     description="指定した期間で順位が下降した企業を取得します。",
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="path",
+     *         required=true,
+     *         description="期間タイプ",
+     *         @OA\Schema(type="string", enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}, example="1m")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         description="取得件数（最大50）",
+     *         @OA\Schema(type="integer", default=10, maximum=50, example=10)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="順位下降企業リスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(type="object",
+     *                 @OA\Property(property="company_name", type="string", example="Falling Company"),
+     *                 @OA\Property(property="domain", type="string", example="falling.com"),
+     *                 @OA\Property(property="current_rank", type="integer", example=15),
+     *                 @OA\Property(property="previous_rank", type="integer", example=8),
+     *                 @OA\Property(property="rank_change", type="integer", example=-7),
+     *                 @OA\Property(property="calculated_at", type="string", format="date-time")
+     *             )),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="period", type="string"),
+     *                 @OA\Property(property="limit", type="integer"),
+     *                 @OA\Property(property="total", type="integer")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正な期間タイプ",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function fallers(Request $request, string $period): JsonResponse
     {
@@ -263,7 +509,42 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 順位変動統計取得
+     * @OA\Get(
+     *     path="/api/rankings/{period}/statistics",
+     *     tags={"企業ランキング"},
+     *     summary="順位変動統計取得",
+     *     description="指定した期間の順位変動統計情報を取得します。",
+     *     @OA\Parameter(
+     *         name="period",
+     *         in="path",
+     *         required=true,
+     *         description="期間タイプ",
+     *         @OA\Schema(type="string", enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}, example="1m")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="順位変動統計",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="total_companies", type="integer", example=100),
+     *                 @OA\Property(property="rising_companies", type="integer", example=35),
+     *                 @OA\Property(property="falling_companies", type="integer", example=40),
+     *                 @OA\Property(property="unchanged_companies", type="integer", example=25),
+     *                 @OA\Property(property="average_change", type="number", format="float", example=0.8),
+     *                 @OA\Property(property="max_rise", type="integer", example=12),
+     *                 @OA\Property(property="max_fall", type="integer", example=8),
+     *                 @OA\Property(property="calculated_at", type="string", format="date-time")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正な期間タイプ",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string")
+     *         )
+     *     )
+     * )
      */
     public function changeStatistics(Request $request, string $period): JsonResponse
     {
@@ -289,7 +570,22 @@ class CompanyRankingController extends Controller
     }
 
     /**
-     * 使用可能な期間タイプ一覧取得
+     * @OA\Get(
+     *     path="/api/rankings/periods",
+     *     tags={"企業ランキング"},
+     *     summary="期間タイプ一覧取得",
+     *     description="使用可能な期間タイプの一覧を取得します。",
+     *     @OA\Response(
+     *         response=200,
+     *         description="期間タイプ一覧",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="array", @OA\Items(
+     *                 type="string", 
+     *                 enum={"1w", "1m", "3m", "6m", "1y", "3y", "all"}
+     *             ), example={"1w", "1m", "3m", "6m", "1y", "3y", "all"})
+     *         )
+     *     )
+     * )
      */
     public function periods(): JsonResponse
     {

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -17,7 +17,57 @@ use Symfony\Component\HttpFoundation\Response;
 class SearchController extends Controller
 {
     /**
-     * 企業名検索
+     * @OA\Get(
+     *     path="/api/search/companies",
+     *     tags={"検索"},
+     *     summary="企業検索",
+     *     description="企業名・ドメイン・説明文から企業を検索します。",
+     *     @OA\Parameter(
+     *         name="q",
+     *         in="query",
+     *         required=true,
+     *         description="検索クエリ（1-255文字）",
+     *         @OA\Schema(type="string", minLength=1, maxLength=255, example="Google")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         description="取得件数（最大100）",
+     *         @OA\Schema(type="integer", minimum=1, maximum=100, default=20, example=20)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="検索結果",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="companies", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="name", type="string", example="株式会社サンプル"),
+     *                     @OA\Property(property="domain", type="string", example="sample.com"),
+     *                     @OA\Property(property="description", type="string", example="サンプル企業の説明"),
+     *                     @OA\Property(property="logo_url", type="string", example="https://example.com/logo.png"),
+     *                     @OA\Property(property="website_url", type="string", example="https://sample.com"),
+     *                     @OA\Property(property="is_active", type="boolean", example=true),
+     *                     @OA\Property(property="match_score", type="number", format="float", example=0.95),
+     *                     @OA\Property(property="current_rankings", type="array", @OA\Items(type="object"))
+     *                 ))
+     *             ),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="total_results", type="integer", example=25),
+     *                 @OA\Property(property="search_time", type="number", format="float", example=0.123),
+     *                 @OA\Property(property="query", type="string", example="サンプル")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="検索クエリが無効です"),
+     *             @OA\Property(property="details", type="object")
+     *         )
+     *     )
+     * )
      */
     public function searchCompanies(Request $request): JsonResponse
     {
@@ -84,7 +134,76 @@ class SearchController extends Controller
     }
 
     /**
-     * 記事検索
+     * @OA\Get(
+     *     path="/api/search/articles",
+     *     tags={"検索"},
+     *     summary="記事検索",
+     *     description="記事タイトル・著者名から記事を検索します。",
+     *     @OA\Parameter(
+     *         name="q",
+     *         in="query",
+     *         required=true,
+     *         description="検索クエリ（1-255文字）",
+     *         @OA\Schema(type="string", minLength=1, maxLength=255, example="Laravel")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         description="取得件数（最大100）",
+     *         @OA\Schema(type="integer", minimum=1, maximum=100, default=20, example=20)
+     *     ),
+     *     @OA\Parameter(
+     *         name="days",
+     *         in="query",
+     *         description="検索対象期間（日数）",
+     *         @OA\Schema(type="integer", minimum=1, maximum=365, default=30, example=30)
+     *     ),
+     *     @OA\Parameter(
+     *         name="min_bookmarks",
+     *         in="query",
+     *         description="最小ブックマーク数",
+     *         @OA\Schema(type="integer", minimum=0, default=0, example=0)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="検索結果",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="articles", type="array", @OA\Items(type="object",
+     *                     @OA\Property(property="id", type="integer", example=1),
+     *                     @OA\Property(property="title", type="string", example="Laravel入門ガイド"),
+     *                     @OA\Property(property="url", type="string", example="https://qiita.com/sample/items/12345"),
+     *                     @OA\Property(property="domain", type="string", example="qiita.com"),
+     *                     @OA\Property(property="platform", type="string", example="Qiita"),
+     *                     @OA\Property(property="author_name", type="string", example="sample_author"),
+     *                     @OA\Property(property="author_url", type="string", example="https://qiita.com/sample_author"),
+     *                     @OA\Property(property="published_at", type="string", format="date-time"),
+     *                     @OA\Property(property="bookmark_count", type="integer", example=125),
+     *                     @OA\Property(property="likes_count", type="integer", example=45),
+     *                     @OA\Property(property="match_score", type="number", format="float", example=0.92),
+     *                     @OA\Property(property="company", type="object"),
+     *                     @OA\Property(property="platform_details", type="object")
+     *                 ))
+     *             ),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="total_results", type="integer", example=15),
+     *                 @OA\Property(property="search_time", type="number", format="float", example=0.089),
+     *                 @OA\Property(property="query", type="string", example="Laravel"),
+     *                 @OA\Property(property="filters", type="object",
+     *                     @OA\Property(property="days", type="integer", example=30),
+     *                     @OA\Property(property="min_bookmarks", type="integer", example=0)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="検索クエリが無効です")
+     *         )
+     *     )
+     * )
      */
     public function searchArticles(Request $request): JsonResponse
     {
@@ -158,7 +277,70 @@ class SearchController extends Controller
     }
 
     /**
-     * 統合検索
+     * @OA\Get(
+     *     path="/api/search",
+     *     tags={"検索"},
+     *     summary="統合検索",
+     *     description="企業・記事を横断的に検索します。",
+     *     @OA\Parameter(
+     *         name="q",
+     *         in="query",
+     *         required=true,
+     *         description="検索クエリ（1-255文字）",
+     *         @OA\Schema(type="string", minLength=1, maxLength=255, example="Laravel")
+     *     ),
+     *     @OA\Parameter(
+     *         name="type",
+     *         in="query",
+     *         description="検索タイプ",
+     *         @OA\Schema(type="string", enum={"companies", "articles", "all"}, default="all", example="all")
+     *     ),
+     *     @OA\Parameter(
+     *         name="limit",
+     *         in="query",
+     *         description="取得件数（最大100）",
+     *         @OA\Schema(type="integer", minimum=1, maximum=100, default=20, example=20)
+     *     ),
+     *     @OA\Parameter(
+     *         name="days",
+     *         in="query",
+     *         description="記事検索の対象期間（日数）",
+     *         @OA\Schema(type="integer", minimum=1, maximum=365, default=30, example=30)
+     *     ),
+     *     @OA\Parameter(
+     *         name="min_bookmarks",
+     *         in="query",
+     *         description="記事検索の最小ブックマーク数",
+     *         @OA\Schema(type="integer", minimum=0, default=0, example=0)
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="検索結果",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="companies", type="array", @OA\Items(type="object")),
+     *                 @OA\Property(property="articles", type="array", @OA\Items(type="object"))
+     *             ),
+     *             @OA\Property(property="meta", type="object",
+     *                 @OA\Property(property="total_results", type="integer", example=40),
+     *                 @OA\Property(property="search_time", type="number", format="float", example=0.156),
+     *                 @OA\Property(property="query", type="string", example="Laravel"),
+     *                 @OA\Property(property="type", type="string", example="all"),
+     *                 @OA\Property(property="filters", type="object",
+     *                     @OA\Property(property="days", type="integer", example=30),
+     *                     @OA\Property(property="min_bookmarks", type="integer", example=0)
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=400,
+     *         description="不正なリクエスト",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="error", type="string", example="検索クエリが無効です")
+     *         )
+     *     )
+     * )
      */
     public function search(Request $request): JsonResponse
     {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,6 +2,32 @@
 
 namespace App\Http\Controllers;
 
+/**
+ * @OA\Info(
+ *     title="Trends Laravel API",
+ *     version="1.0.0",
+ *     description="企業の技術コミュニティでの影響力を分析・追跡するAPI",
+ *     @OA\Contact(
+ *         email="admin@example.com"
+ *     )
+ * )
+ * @OA\Server(
+ *     url=L5_SWAGGER_CONST_HOST,
+ *     description="API Server"
+ * )
+ * @OA\Tag(
+ *     name="企業詳細",
+ *     description="企業の詳細情報、記事一覧、影響力スコア履歴、ランキング情報を提供するAPI"
+ * )
+ * @OA\Tag(
+ *     name="企業ランキング",
+ *     description="企業の技術コミュニティでの影響力ランキングデータを提供するAPI"
+ * )
+ * @OA\Tag(
+ *     name="検索",
+ *     description="企業・記事・技術キーワードを検索するAPI"
+ * )
+ */
 abstract class Controller
 {
     //

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "darkaonline/l5-swagger": "^9.0",
         "guzzlehttp/guzzle": "^7.9",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f36f92948760fd7b5451cd9b2bea37b7",
+    "content-hash": "2b8a1eedd1632e169d001f39f5182046",
     "packages": [
         {
             "name": "brick/math",
@@ -136,6 +136,87 @@
             "time": "2024-02-09T16:56:22+00:00"
         },
         {
+            "name": "darkaonline/l5-swagger",
+            "version": "9.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DarkaOnLine/L5-Swagger.git",
+                "reference": "2c26427f8c41db8e72232415e7287313e6b6a2e2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DarkaOnLine/L5-Swagger/zipball/2c26427f8c41db8e72232415e7287313e6b6a2e2",
+                "reference": "2c26427f8c41db8e72232415e7287313e6b6a2e2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.0 || ^2.0",
+                "ext-json": "*",
+                "laravel/framework": "^12.0 || ^11.0",
+                "php": "^8.2",
+                "swagger-api/swagger-ui": ">=5.18.3",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0",
+                "zircote/swagger-php": "^5.0.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "1.*",
+                "orchestra/testbench": "^10.0 || ^9.0 || ^8.0 || 7.* || ^6.15 || 5.*",
+                "php-coveralls/php-coveralls": "^2.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "L5Swagger": "L5Swagger\\L5SwaggerFacade"
+                    },
+                    "providers": [
+                        "L5Swagger\\L5SwaggerServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "L5Swagger\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Darius Matulionis",
+                    "email": "darius@matulionis.lt"
+                }
+            ],
+            "description": "OpenApi or Swagger integration to Laravel",
+            "keywords": [
+                "api",
+                "documentation",
+                "laravel",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/DarkaOnLine/L5-Swagger/issues",
+                "source": "https://github.com/DarkaOnLine/L5-Swagger/tree/9.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/DarkaOnLine",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-28T06:25:02+00:00"
+        },
+        {
             "name": "dflydev/dot-access-data",
             "version": "v3.0.3",
             "source": {
@@ -209,6 +290,82 @@
                 "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.3"
             },
             "time": "2024-07-08T12:26:09+00:00"
+        },
+        {
+            "name": "doctrine/annotations",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "reference": "901c2ee5d26eb64ff43c47976e114bf00843acf7",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2 || ^3",
+                "ext-tokenizer": "*",
+                "php": "^7.2 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^2.0",
+                "doctrine/coding-standard": "^10",
+                "phpstan/phpstan": "^1.10.28",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "symfony/cache": "^5.4 || ^6.4 || ^7",
+                "vimeo/psalm": "^4.30 || ^5.14"
+            },
+            "suggest": {
+                "php": "PHP 8.0 or higher comes with attributes, a native replacement for annotations"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/2.0.2"
+            },
+            "time": "2024-09-05T10:17:24+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -2650,6 +2807,55 @@
             "time": "2024-07-20T21:41:07+00:00"
         },
         {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
+        },
+        {
             "name": "psr/clock",
             "version": "1.0.0",
             "source": {
@@ -3337,6 +3543,67 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
             "time": "2025-06-25T14:20:11+00:00"
+        },
+        {
+            "name": "swagger-api/swagger-ui",
+            "version": "v5.26.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swagger-api/swagger-ui.git",
+                "reference": "059cfe3734846519cd55752326c4b191bf682ca2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swagger-api/swagger-ui/zipball/059cfe3734846519cd55752326c4b191bf682ca2",
+                "reference": "059cfe3734846519cd55752326c4b191bf682ca2",
+                "shasum": ""
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Anna Bodnia",
+                    "email": "anna.bodnia@gmail.com"
+                },
+                {
+                    "name": "Buu Nguyen",
+                    "email": "buunguyen@gmail.com"
+                },
+                {
+                    "name": "Josh Ponelat",
+                    "email": "jponelat@gmail.com"
+                },
+                {
+                    "name": "Kyle Shockey",
+                    "email": "kyleshockey1@gmail.com"
+                },
+                {
+                    "name": "Robert Barnwell",
+                    "email": "robert@robertismy.name"
+                },
+                {
+                    "name": "Sahar Jafari",
+                    "email": "shr.jafari@gmail.com"
+                }
+            ],
+            "description": " Swagger UI is a collection of HTML, Javascript, and CSS assets that dynamically generate beautiful documentation from a Swagger-compliant API.",
+            "homepage": "http://swagger.io",
+            "keywords": [
+                "api",
+                "documentation",
+                "openapi",
+                "specification",
+                "swagger",
+                "ui"
+            ],
+            "support": {
+                "issues": "https://github.com/swagger-api/swagger-ui/issues",
+                "source": "https://github.com/swagger-api/swagger-ui/tree/v5.26.1"
+            },
+            "time": "2025-07-07T06:11:57+00:00"
         },
         {
             "name": "symfony/clock",
@@ -5641,6 +5908,78 @@
             "time": "2025-06-27T19:55:54+00:00"
         },
         {
+            "name": "symfony/yaml",
+            "version": "v7.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0c3555045a46ab3cd4cc5a69d161225195230edb",
+                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<6.4"
+            },
+            "require-dev": {
+                "symfony/console": "^6.4|^7.0"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v7.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-03T06:57:57+00:00"
+        },
+        {
             "name": "tijsverkoyen/css-to-inline-styles",
             "version": "v2.3.0",
             "source": {
@@ -5910,6 +6249,92 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "b8ba6bd99805c0ae09a38d1b26c1c92820509bd0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/b8ba6bd99805c0ae09a38d1b26c1c92820509bd0",
+                "reference": "b8ba6bd99805c0ae09a38d1b26c1c92820509bd0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=7.4",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.0 || ^6.0 || ^7.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "composer/package-versions-deprecated": "^1.11",
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "phpstan/phpstan": "^1.6 || ^2.0",
+                "phpunit/phpunit": "^9.0",
+                "rector/rector": "^1.0 || ^2.0",
+                "vimeo/psalm": "^4.30 || ^5.0"
+            },
+            "suggest": {
+                "doctrine/annotations": "^2.0"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/5.1.3"
+            },
+            "time": "2025-05-20T03:35:10+00:00"
         }
     ],
     "packages-dev": [
@@ -8290,78 +8715,6 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v7.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/0c3555045a46ab3cd4cc5a69d161225195230edb",
-                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "^1.8"
-            },
-            "conflict": {
-                "symfony/console": "<6.4"
-            },
-            "require-dev": {
-                "symfony/console": "^6.4|^7.0"
-            },
-            "bin": [
-                "Resources/bin/yaml-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Loads and dumps YAML files",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-06-03T06:57:57+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -1,0 +1,318 @@
+<?php
+
+return [
+    'default' => 'default',
+    'documentations' => [
+        'default' => [
+            'api' => [
+                'title' => 'Trends Laravel API Documentation',
+            ],
+
+            'routes' => [
+                /*
+                 * Route for accessing api documentation interface
+                 */
+                'api' => 'api/documentation',
+            ],
+            'paths' => [
+                /*
+                 * Edit to include full URL in ui for assets
+                 */
+                'use_absolute_path' => env('L5_SWAGGER_USE_ABSOLUTE_PATH', true),
+
+                /*
+                * Edit to set path where swagger ui assets should be stored
+                */
+                'swagger_ui_assets_path' => env('L5_SWAGGER_UI_ASSETS_PATH', 'vendor/swagger-api/swagger-ui/dist/'),
+
+                /*
+                 * File name of the generated json documentation file
+                 */
+                'docs_json' => 'api-docs.json',
+
+                /*
+                 * File name of the generated YAML documentation file
+                 */
+                'docs_yaml' => 'api-docs.yaml',
+
+                /*
+                 * Set this to `json` or `yaml` to determine which documentation file to use in UI
+                 */
+                'format_to_use_for_docs' => env('L5_FORMAT_TO_USE_FOR_DOCS', 'json'),
+
+                /*
+                 * Absolute paths to directory containing the swagger annotations are stored.
+                 */
+                'annotations' => [
+                    base_path('app'),
+                ],
+            ],
+        ],
+    ],
+    'defaults' => [
+        'routes' => [
+            /*
+             * Route for accessing parsed swagger annotations.
+             */
+            'docs' => 'docs',
+
+            /*
+             * Route for Oauth2 authentication callback.
+             */
+            'oauth2_callback' => 'api/oauth2-callback',
+
+            /*
+             * Middleware allows to prevent unexpected access to API documentation
+             */
+            'middleware' => [
+                'api' => [],
+                'asset' => [],
+                'docs' => [],
+                'oauth2_callback' => [],
+            ],
+
+            /*
+             * Route Group options
+             */
+            'group_options' => [],
+        ],
+
+        'paths' => [
+            /*
+             * Absolute path to location where parsed annotations will be stored
+             */
+            'docs' => storage_path('api-docs'),
+
+            /*
+             * Absolute path to directory where to export views
+             */
+            'views' => base_path('resources/views/vendor/l5-swagger'),
+
+            /*
+             * Edit to set the api's base path
+             */
+            'base' => env('L5_SWAGGER_BASE_PATH', null),
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @deprecated Please use `scanOptions.exclude`
+             * `scanOptions.exclude` overwrites this
+             */
+            'excludes' => [],
+        ],
+
+        'scanOptions' => [
+            /**
+             * Configuration for default processors. Allows to pass processors configuration to swagger-php.
+             *
+             * @link https://zircote.github.io/swagger-php/reference/processors.html
+             */
+            'default_processors_configuration' => [
+            /** Example */
+            /**
+             * 'operationId.hash' => true,
+             * 'pathFilter' => [
+             * 'tags' => [
+             * '/pets/',
+             * '/store/',
+             * ],
+             * ],.
+             */
+            ],
+
+            /**
+             * analyser: defaults to \OpenApi\StaticAnalyser .
+             *
+             * @see \OpenApi\scan
+             */
+            'analyser' => null,
+
+            /**
+             * analysis: defaults to a new \OpenApi\Analysis .
+             *
+             * @see \OpenApi\scan
+             */
+            'analysis' => null,
+
+            /**
+             * Custom query path processors classes.
+             *
+             * @link https://github.com/zircote/swagger-php/tree/master/Examples/processors/schema-query-parameter
+             * @see \OpenApi\scan
+             */
+            'processors' => [
+                // new \App\SwaggerProcessors\SchemaQueryParameter(),
+            ],
+
+            /**
+             * pattern: string       $pattern File pattern(s) to scan (default: *.php) .
+             *
+             * @see \OpenApi\scan
+             */
+            'pattern' => null,
+
+            /*
+             * Absolute path to directories that should be excluded from scanning
+             * @note This option overwrites `paths.excludes`
+             * @see \OpenApi\scan
+             */
+            'exclude' => [],
+
+            /*
+             * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
+             * By default the spec will be in version 3.0.0
+             */
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+        ],
+
+        /*
+         * API security definitions. Will be generated into documentation file.
+        */
+        'securityDefinitions' => [
+            'securitySchemes' => [
+                /*
+                 * Examples of Security schemes
+                 */
+                /*
+                'api_key_security_example' => [ // Unique name of security
+                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for security scheme',
+                    'name' => 'api_key', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                'oauth2_security_example' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'A short description for oauth2 security scheme.',
+                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
+                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
+                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
+                    'scopes' => [
+                        'read:projects' => 'read your projects',
+                        'write:projects' => 'modify projects in your account',
+                    ]
+                ],
+                */
+
+                /* Open API 3.0 support
+                'passport' => [ // Unique name of security
+                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Laravel passport oauth2 security.',
+                    'in' => 'header',
+                    'scheme' => 'https',
+                    'flows' => [
+                        "password" => [
+                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
+                            "tokenUrl" => config('app.url') . '/oauth/token',
+                            "refreshUrl" => config('app.url') . '/token/refresh',
+                            "scopes" => []
+                        ],
+                    ],
+                ],
+                'sanctum' => [ // Unique name of security
+                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
+                    'description' => 'Enter token in format (Bearer <token>)',
+                    'name' => 'Authorization', // The name of the header or query parameter to be used.
+                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                ],
+                */
+            ],
+            'security' => [
+                /*
+                 * Examples of Securities
+                 */
+                [
+                    /*
+                    'oauth2_security_example' => [
+                        'read',
+                        'write'
+                    ],
+
+                    'passport' => []
+                    */
+                ],
+            ],
+        ],
+
+        /*
+         * Set this to `true` in development mode so that docs would be regenerated on each request
+         * Set this to `false` to disable swagger generation on production
+         */
+        'generate_always' => env('L5_SWAGGER_GENERATE_ALWAYS', false),
+
+        /*
+         * Set this to `true` to generate a copy of documentation in yaml format
+         */
+        'generate_yaml_copy' => env('L5_SWAGGER_GENERATE_YAML_COPY', false),
+
+        /*
+         * Edit to trust the proxy's ip address - needed for AWS Load Balancer
+         * string[]
+         */
+        'proxy' => false,
+
+        /*
+         * Configs plugin allows to fetch external configs instead of passing them to SwaggerUIBundle.
+         * See more at: https://github.com/swagger-api/swagger-ui#configs-plugin
+         */
+        'additional_config_url' => null,
+
+        /*
+         * Apply a sort to the operation list of each API. It can be 'alpha' (sort by paths alphanumerically),
+         * 'method' (sort by HTTP method).
+         * Default is the order returned by the server unchanged.
+         */
+        'operations_sort' => env('L5_SWAGGER_OPERATIONS_SORT', null),
+
+        /*
+         * Pass the validatorUrl parameter to SwaggerUi init on the JS side.
+         * A null value here disables validation.
+         */
+        'validator_url' => null,
+
+        /*
+         * Swagger UI configuration parameters
+         */
+        'ui' => [
+            'display' => [
+                'dark_mode' => env('L5_SWAGGER_UI_DARK_MODE', false),
+                /*
+                 * Controls the default expansion setting for the operations and tags. It can be :
+                 * 'list' (expands only the tags),
+                 * 'full' (expands the tags and operations),
+                 * 'none' (expands nothing).
+                 */
+                'doc_expansion' => env('L5_SWAGGER_UI_DOC_EXPANSION', 'none'),
+
+                /**
+                 * If set, enables filtering. The top bar will show an edit box that
+                 * you can use to filter the tagged operations that are shown. Can be
+                 * Boolean to enable or disable, or a string, in which case filtering
+                 * will be enabled using that string as the filter expression. Filtering
+                 * is case-sensitive matching the filter expression anywhere inside
+                 * the tag.
+                 */
+                'filter' => env('L5_SWAGGER_UI_FILTERS', true), // true | false
+            ],
+
+            'authorization' => [
+                /*
+                 * If set to true, it persists authorization data, and it would not be lost on browser close/refresh
+                 */
+                'persist_authorization' => env('L5_SWAGGER_UI_PERSIST_AUTHORIZATION', false),
+
+                'oauth2' => [
+                    /*
+                     * If set to true, adds PKCE to AuthorizationCodeGrant flow
+                     */
+                    'use_pkce_with_authorization_code_grant' => false,
+                ],
+            ],
+        ],
+        /*
+         * Constants which can be used in annotations
+         */
+        'constants' => [
+            'L5_SWAGGER_CONST_HOST' => env('L5_SWAGGER_CONST_HOST', 'http://my-default-host.com'),
+        ],
+    ],
+];

--- a/resources/views/vendor/l5-swagger/index.blade.php
+++ b/resources/views/vendor/l5-swagger/index.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ $documentationTitle }}</title>
+    <link rel="stylesheet" type="text/css" href="{{ l5_swagger_asset($documentation, 'swagger-ui.css') }}">
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-32x32.png') }}" sizes="32x32"/>
+    <link rel="icon" type="image/png" href="{{ l5_swagger_asset($documentation, 'favicon-16x16.png') }}" sizes="16x16"/>
+    <style>
+    html
+    {
+        box-sizing: border-box;
+        overflow: -moz-scrollbars-vertical;
+        overflow-y: scroll;
+    }
+    *,
+    *:before,
+    *:after
+    {
+        box-sizing: inherit;
+    }
+
+    body {
+      margin:0;
+      background: #fafafa;
+    }
+    </style>
+    @if(config('l5-swagger.defaults.ui.display.dark_mode'))
+        <style>
+            body#dark-mode,
+            #dark-mode .scheme-container {
+                background: #1b1b1b;
+            }
+            #dark-mode .scheme-container,
+            #dark-mode .opblock .opblock-section-header{
+                box-shadow: 0 1px 2px 0 rgba(255, 255, 255, 0.15);
+            }
+            #dark-mode .operation-filter-input,
+            #dark-mode .dialog-ux .modal-ux,
+            #dark-mode input[type=email],
+            #dark-mode input[type=file],
+            #dark-mode input[type=password],
+            #dark-mode input[type=search],
+            #dark-mode input[type=text],
+            #dark-mode textarea{
+                background: #343434;
+                color: #e7e7e7;
+            }
+            #dark-mode .title,
+            #dark-mode li,
+            #dark-mode p,
+            #dark-mode table,
+            #dark-mode label,
+            #dark-mode .opblock-tag,
+            #dark-mode .opblock .opblock-summary-operation-id,
+            #dark-mode .opblock .opblock-summary-path,
+            #dark-mode .opblock .opblock-summary-path__deprecated,
+            #dark-mode h1,
+            #dark-mode h2,
+            #dark-mode h3,
+            #dark-mode h4,
+            #dark-mode h5,
+            #dark-mode .btn,
+            #dark-mode .tab li,
+            #dark-mode .parameter__name,
+            #dark-mode .parameter__type,
+            #dark-mode .prop-format,
+            #dark-mode .loading-container .loading:after{
+                color: #e7e7e7;
+            }
+            #dark-mode .opblock-description-wrapper p,
+            #dark-mode .opblock-external-docs-wrapper p,
+            #dark-mode .opblock-title_normal p,
+            #dark-mode .response-col_status,
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th,
+            #dark-mode .response-col_links,
+            #dark-mode .swagger-ui{
+                color: wheat;
+            }
+            #dark-mode .parameter__extension,
+            #dark-mode .parameter__in,
+            #dark-mode .model-title{
+                color: #949494;
+            }
+            #dark-mode table thead tr td,
+            #dark-mode table thead tr th{
+                border-color: rgba(120,120,120,.2);
+            }
+            #dark-mode .opblock .opblock-section-header{
+                background: transparent;
+            }
+            #dark-mode .opblock.opblock-post{
+                background: rgba(73,204,144,.25);
+            }
+            #dark-mode .opblock.opblock-get{
+                background: rgba(97,175,254,.25);
+            }
+            #dark-mode .opblock.opblock-put{
+                background: rgba(252,161,48,.25);
+            }
+            #dark-mode .opblock.opblock-delete{
+                background: rgba(249,62,62,.25);
+            }
+            #dark-mode .loading-container .loading:before{
+                border-color: rgba(255,255,255,10%);
+                border-top-color: rgba(255,255,255,.6);
+            }
+            #dark-mode svg:not(:root){
+                fill: #e7e7e7;
+            }
+            #dark-mode .opblock-summary-description {
+                color: #fafafa;
+            }
+        </style>
+    @endif
+</head>
+
+<body @if(config('l5-swagger.defaults.ui.display.dark_mode')) id="dark-mode" @endif>
+<div id="swagger-ui"></div>
+
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-bundle.js') }}"></script>
+<script src="{{ l5_swagger_asset($documentation, 'swagger-ui-standalone-preset.js') }}"></script>
+<script>
+    window.onload = function() {
+        const urls = [];
+
+        @foreach($urlsToDocs as $title => $url)
+            urls.push({name: "{{ $title }}", url: "{{ $url }}"});
+        @endforeach
+
+        // Build a system
+        const ui = SwaggerUIBundle({
+            dom_id: '#swagger-ui',
+            urls: urls,
+            "urls.primaryName": "{{ $documentationTitle }}",
+            operationsSorter: {!! isset($operationsSorter) ? '"' . $operationsSorter . '"' : 'null' !!},
+            configUrl: {!! isset($configUrl) ? '"' . $configUrl . '"' : 'null' !!},
+            validatorUrl: {!! isset($validatorUrl) ? '"' . $validatorUrl . '"' : 'null' !!},
+            oauth2RedirectUrl: "{{ route('l5-swagger.'.$documentation.'.oauth2_callback', [], $useAbsolutePath) }}",
+
+            requestInterceptor: function(request) {
+                request.headers['X-CSRF-TOKEN'] = '{{ csrf_token() }}';
+                return request;
+            },
+
+            presets: [
+                SwaggerUIBundle.presets.apis,
+                SwaggerUIStandalonePreset
+            ],
+
+            plugins: [
+                SwaggerUIBundle.plugins.DownloadUrl
+            ],
+
+            layout: "StandaloneLayout",
+            docExpansion : "{!! config('l5-swagger.defaults.ui.display.doc_expansion', 'none') !!}",
+            deepLinking: true,
+            filter: {!! config('l5-swagger.defaults.ui.display.filter') ? 'true' : 'false' !!},
+            persistAuthorization: "{!! config('l5-swagger.defaults.ui.authorization.persist_authorization') ? 'true' : 'false' !!}",
+
+        })
+
+        window.ui = ui
+
+        @if(in_array('oauth2', array_column(config('l5-swagger.defaults.securityDefinitions.securitySchemes'), 'type')))
+        ui.initOAuth({
+            usePkceWithAuthorizationCodeGrant: "{!! (bool)config('l5-swagger.defaults.ui.authorization.oauth2.use_pkce_with_authorization_code_grant') !!}"
+        })
+        @endif
+    }
+</script>
+</body>
+</html>

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1,0 +1,1767 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Trends Laravel API",
+        "description": "企業の技術コミュニティでの影響力を分析・追跡するAPI",
+        "contact": {
+            "email": "admin@example.com"
+        },
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "http://localhost:8000",
+            "description": "API Server"
+        }
+    ],
+    "paths": {
+        "/api/companies/{company_id}": {
+            "get": {
+                "tags": [
+                    "企業詳細"
+                ],
+                "summary": "企業詳細情報取得",
+                "description": "企業の詳細情報を取得します。現在のランキング情報と最近の記事（最大5件）を含みます。",
+                "operationId": "b87956b293dcfbb97d69bf77d6d496cc",
+                "parameters": [
+                    {
+                        "name": "company_id",
+                        "in": "path",
+                        "description": "企業ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "企業詳細情報",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Company A"
+                                                },
+                                                "domain": {
+                                                    "type": "string",
+                                                    "example": "company-a.com"
+                                                },
+                                                "description": {
+                                                    "type": "string",
+                                                    "example": "企業の説明文"
+                                                },
+                                                "logo_url": {
+                                                    "type": "string",
+                                                    "example": "https://example.com/logo.png"
+                                                },
+                                                "website_url": {
+                                                    "type": "string",
+                                                    "example": "https://company-a.com"
+                                                },
+                                                "is_active": {
+                                                    "type": "boolean",
+                                                    "example": true
+                                                },
+                                                "current_rankings": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "recent_articles": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業IDが無効です"
+                                        },
+                                        "details": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "企業が見つかりません",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業が見つかりません"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/companies/{company_id}/articles": {
+            "get": {
+                "tags": [
+                    "企業詳細"
+                ],
+                "summary": "企業の記事一覧取得",
+                "description": "企業に関連する記事の一覧を取得します。",
+                "operationId": "a6fca0b29fa759399957964775c3bb6f",
+                "parameters": [
+                    {
+                        "name": "company_id",
+                        "in": "path",
+                        "description": "企業ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "ページ番号",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1,
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "1ページあたりの件数（最大100）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "maximum": 100,
+                            "example": 20
+                        }
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "過去何日分の記事を取得するか",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                        }
+                    },
+                    {
+                        "name": "min_bookmarks",
+                        "in": "query",
+                        "description": "最小ブックマーク数",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "example": 0
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "記事一覧",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer"
+                                                },
+                                                "per_page": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                },
+                                                "last_page": {
+                                                    "type": "integer"
+                                                },
+                                                "company_id": {
+                                                    "type": "integer"
+                                                },
+                                                "filters": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業IDが無効です"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "企業が見つかりません",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業が見つかりません"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/companies/{company_id}/scores": {
+            "get": {
+                "tags": [
+                    "企業詳細"
+                ],
+                "summary": "企業の影響力スコア履歴取得",
+                "description": "企業の影響力スコアの履歴データを取得します。",
+                "operationId": "30d331d44d5ca7009a0cd5bae88aaf5d",
+                "parameters": [
+                    {
+                        "name": "company_id",
+                        "in": "path",
+                        "description": "企業ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "period",
+                        "in": "query",
+                        "description": "期間タイプ",
+                        "schema": {
+                            "type": "string",
+                            "default": "1d",
+                            "example": "1d"
+                        }
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "過去何日分のスコアを取得するか",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "スコア履歴",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "company_id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "scores": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "date": {
+                                                                "type": "string",
+                                                                "format": "date",
+                                                                "example": "2024-01-30"
+                                                            },
+                                                            "score": {
+                                                                "type": "number",
+                                                                "format": "float",
+                                                                "example": 85.5
+                                                            },
+                                                            "rank_position": {
+                                                                "type": "integer",
+                                                                "example": 5
+                                                            },
+                                                            "calculated_at": {
+                                                                "type": "string",
+                                                                "format": "date-time"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "period": {
+                                                    "type": "string"
+                                                },
+                                                "days": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業IDが無効です"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "企業が見つかりません",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業が見つかりません"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/companies/{company_id}/rankings": {
+            "get": {
+                "tags": [
+                    "企業詳細"
+                ],
+                "summary": "企業のランキング情報取得",
+                "description": "企業の各期間でのランキング情報を取得します。",
+                "operationId": "a50a508b0b1a0310be13e75c95aaacfc",
+                "parameters": [
+                    {
+                        "name": "company_id",
+                        "in": "path",
+                        "description": "企業ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "include_history",
+                        "in": "query",
+                        "description": "履歴を含める",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "example": false
+                        }
+                    },
+                    {
+                        "name": "history_days",
+                        "in": "query",
+                        "description": "履歴取得日数",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ランキング情報",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "company_id": {
+                                                    "type": "integer",
+                                                    "example": 1
+                                                },
+                                                "rankings": {
+                                                    "type": "object"
+                                                },
+                                                "history": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業IDが無効です"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "企業が見つかりません",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "企業が見つかりません"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/{period}": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "期間別ランキング取得",
+                "description": "指定した期間の企業ランキングを取得します。",
+                "operationId": "2a59ef3da07e77296fd7d929cd34076e",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "path",
+                        "description": "期間タイプ (1w, 1m, 3m, 6m, 1y, 3y, all)",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1w",
+                                "1m",
+                                "3m",
+                                "6m",
+                                "1y",
+                                "3y",
+                                "all"
+                            ],
+                            "example": "1m"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "in": "query",
+                        "description": "ページ番号",
+                        "schema": {
+                            "type": "integer",
+                            "default": 1,
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "per_page",
+                        "in": "query",
+                        "description": "1ページあたりの件数（最大100）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "maximum": 100,
+                            "example": 20
+                        }
+                    },
+                    {
+                        "name": "sort_by",
+                        "in": "query",
+                        "description": "ソート項目",
+                        "schema": {
+                            "type": "string",
+                            "default": "rank_position",
+                            "example": "rank_position"
+                        }
+                    },
+                    {
+                        "name": "sort_order",
+                        "in": "query",
+                        "description": "ソート順",
+                        "schema": {
+                            "type": "string",
+                            "default": "asc",
+                            "enum": [
+                                "asc",
+                                "desc"
+                            ],
+                            "example": "asc"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ランキングリスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "current_page": {
+                                                    "type": "integer"
+                                                },
+                                                "per_page": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                },
+                                                "last_page": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な期間タイプ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/{period}/top/{limit}": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "上位N件のランキング取得",
+                "description": "指定した期間の上位N件のランキングを取得します。",
+                "operationId": "78594b53d7fae9a30415e698a61b925f",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "path",
+                        "description": "期間タイプ",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1w",
+                                "1m",
+                                "3m",
+                                "6m",
+                                "1y",
+                                "3y",
+                                "all"
+                            ],
+                            "example": "1m"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "path",
+                        "description": "取得件数 (1-100)",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "maximum": 100,
+                            "minimum": 1,
+                            "example": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "上位ランキング",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "period": {
+                                                    "type": "string"
+                                                },
+                                                "limit": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なパラメータ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/company/{company_id}": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "特定企業のランキング取得",
+                "description": "特定企業の全期間ランキング情報を取得します。",
+                "operationId": "e8eb4538d14b415d668f8a5a75aa0201",
+                "parameters": [
+                    {
+                        "name": "company_id",
+                        "in": "path",
+                        "description": "企業ID",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "example": 1
+                        }
+                    },
+                    {
+                        "name": "include_history",
+                        "in": "query",
+                        "description": "履歴を含める",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false,
+                            "example": false
+                        }
+                    },
+                    {
+                        "name": "history_days",
+                        "in": "query",
+                        "description": "履歴取得日数",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "example": 30
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "企業ランキング情報",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "company_id": {
+                                                    "type": "integer"
+                                                },
+                                                "rankings": {
+                                                    "type": "object"
+                                                },
+                                                "history": {
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な企業ID",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/statistics": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "ランキング統計情報取得",
+                "description": "全期間のランキング統計情報を取得します。",
+                "operationId": "ebaf8a89cfb807d32cf6da1240d44b60",
+                "responses": {
+                    "200": {
+                        "description": "統計情報",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "1m": {
+                                                    "properties": {
+                                                        "total_companies": {
+                                                            "type": "integer",
+                                                            "example": 100
+                                                        },
+                                                        "average_score": {
+                                                            "type": "number",
+                                                            "format": "float",
+                                                            "example": 50.25
+                                                        },
+                                                        "max_score": {
+                                                            "type": "number",
+                                                            "format": "float",
+                                                            "example": 150.75
+                                                        },
+                                                        "min_score": {
+                                                            "type": "number",
+                                                            "format": "float",
+                                                            "example": 5.1
+                                                        },
+                                                        "total_articles": {
+                                                            "type": "integer",
+                                                            "example": 1000
+                                                        },
+                                                        "total_bookmarks": {
+                                                            "type": "integer",
+                                                            "example": 50000
+                                                        },
+                                                        "last_calculated": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/{period}/risers": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "順位上昇企業取得",
+                "description": "指定した期間で順位が上昇した企業を取得します。",
+                "operationId": "4291c8cb4bd975a76eb0612b090bc2b3",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "path",
+                        "description": "期間タイプ",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1w",
+                                "1m",
+                                "3m",
+                                "6m",
+                                "1y",
+                                "3y",
+                                "all"
+                            ],
+                            "example": "1m"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "取得件数（最大50）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "maximum": 50,
+                            "example": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "順位上昇企業リスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "company_name": {
+                                                        "type": "string",
+                                                        "example": "Rising Company"
+                                                    },
+                                                    "domain": {
+                                                        "type": "string",
+                                                        "example": "rising.com"
+                                                    },
+                                                    "current_rank": {
+                                                        "type": "integer",
+                                                        "example": 5
+                                                    },
+                                                    "previous_rank": {
+                                                        "type": "integer",
+                                                        "example": 10
+                                                    },
+                                                    "rank_change": {
+                                                        "type": "integer",
+                                                        "example": 5
+                                                    },
+                                                    "calculated_at": {
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "period": {
+                                                    "type": "string"
+                                                },
+                                                "limit": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な期間タイプ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/{period}/fallers": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "順位下降企業取得",
+                "description": "指定した期間で順位が下降した企業を取得します。",
+                "operationId": "1fd5786a7f0ccdd71c3823e12eca6318",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "path",
+                        "description": "期間タイプ",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1w",
+                                "1m",
+                                "3m",
+                                "6m",
+                                "1y",
+                                "3y",
+                                "all"
+                            ],
+                            "example": "1m"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "取得件数（最大50）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 10,
+                            "maximum": 50,
+                            "example": 10
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "順位下降企業リスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "properties": {
+                                                    "company_name": {
+                                                        "type": "string",
+                                                        "example": "Falling Company"
+                                                    },
+                                                    "domain": {
+                                                        "type": "string",
+                                                        "example": "falling.com"
+                                                    },
+                                                    "current_rank": {
+                                                        "type": "integer",
+                                                        "example": 15
+                                                    },
+                                                    "previous_rank": {
+                                                        "type": "integer",
+                                                        "example": 8
+                                                    },
+                                                    "rank_change": {
+                                                        "type": "integer",
+                                                        "example": -7
+                                                    },
+                                                    "calculated_at": {
+                                                        "type": "string",
+                                                        "format": "date-time"
+                                                    }
+                                                },
+                                                "type": "object"
+                                            }
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "period": {
+                                                    "type": "string"
+                                                },
+                                                "limit": {
+                                                    "type": "integer"
+                                                },
+                                                "total": {
+                                                    "type": "integer"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な期間タイプ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/{period}/statistics": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "順位変動統計取得",
+                "description": "指定した期間の順位変動統計情報を取得します。",
+                "operationId": "fec34322cc5c1aa3b37972e5faf38ac5",
+                "parameters": [
+                    {
+                        "name": "period",
+                        "in": "path",
+                        "description": "期間タイプ",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "1w",
+                                "1m",
+                                "3m",
+                                "6m",
+                                "1y",
+                                "3y",
+                                "all"
+                            ],
+                            "example": "1m"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "順位変動統計",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "total_companies": {
+                                                    "type": "integer",
+                                                    "example": 100
+                                                },
+                                                "rising_companies": {
+                                                    "type": "integer",
+                                                    "example": 35
+                                                },
+                                                "falling_companies": {
+                                                    "type": "integer",
+                                                    "example": 40
+                                                },
+                                                "unchanged_companies": {
+                                                    "type": "integer",
+                                                    "example": 25
+                                                },
+                                                "average_change": {
+                                                    "type": "number",
+                                                    "format": "float",
+                                                    "example": 0.8
+                                                },
+                                                "max_rise": {
+                                                    "type": "integer",
+                                                    "example": 12
+                                                },
+                                                "max_fall": {
+                                                    "type": "integer",
+                                                    "example": 8
+                                                },
+                                                "calculated_at": {
+                                                    "type": "string",
+                                                    "format": "date-time"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正な期間タイプ",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/rankings/periods": {
+            "get": {
+                "tags": [
+                    "企業ランキング"
+                ],
+                "summary": "期間タイプ一覧取得",
+                "description": "使用可能な期間タイプの一覧を取得します。",
+                "operationId": "494cd9bbb44db993095cbe91297c21dc",
+                "responses": {
+                    "200": {
+                        "description": "期間タイプ一覧",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string",
+                                                "enum": [
+                                                    "1w",
+                                                    "1m",
+                                                    "3m",
+                                                    "6m",
+                                                    "1y",
+                                                    "3y",
+                                                    "all"
+                                                ]
+                                            },
+                                            "example": [
+                                                "1w",
+                                                "1m",
+                                                "3m",
+                                                "6m",
+                                                "1y",
+                                                "3y",
+                                                "all"
+                                            ]
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/search/companies": {
+            "get": {
+                "tags": [
+                    "検索"
+                ],
+                "summary": "企業検索",
+                "description": "企業名・ドメイン・説明文から企業を検索します。",
+                "operationId": "65205532c324c7142beb7954d74d90ba",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "検索クエリ（1-255文字）",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "minLength": 1,
+                            "example": "Google"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "取得件数（最大100）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "maximum": 100,
+                            "minimum": 1,
+                            "example": 20
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "検索結果",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "companies": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "example": 1
+                                                            },
+                                                            "name": {
+                                                                "type": "string",
+                                                                "example": "株式会社サンプル"
+                                                            },
+                                                            "domain": {
+                                                                "type": "string",
+                                                                "example": "sample.com"
+                                                            },
+                                                            "description": {
+                                                                "type": "string",
+                                                                "example": "サンプル企業の説明"
+                                                            },
+                                                            "logo_url": {
+                                                                "type": "string",
+                                                                "example": "https://example.com/logo.png"
+                                                            },
+                                                            "website_url": {
+                                                                "type": "string",
+                                                                "example": "https://sample.com"
+                                                            },
+                                                            "is_active": {
+                                                                "type": "boolean",
+                                                                "example": true
+                                                            },
+                                                            "match_score": {
+                                                                "type": "number",
+                                                                "format": "float",
+                                                                "example": 0.95
+                                                            },
+                                                            "current_rankings": {
+                                                                "type": "array",
+                                                                "items": {
+                                                                    "type": "object"
+                                                                }
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total_results": {
+                                                    "type": "integer",
+                                                    "example": 25
+                                                },
+                                                "search_time": {
+                                                    "type": "number",
+                                                    "format": "float",
+                                                    "example": 0.123
+                                                },
+                                                "query": {
+                                                    "type": "string",
+                                                    "example": "サンプル"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "検索クエリが無効です"
+                                        },
+                                        "details": {
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/search/articles": {
+            "get": {
+                "tags": [
+                    "検索"
+                ],
+                "summary": "記事検索",
+                "description": "記事タイトル・著者名から記事を検索します。",
+                "operationId": "fdf80b709ecde3acfef0d13a86558991",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "検索クエリ（1-255文字）",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "minLength": 1,
+                            "example": "Laravel"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "取得件数（最大100）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "maximum": 100,
+                            "minimum": 1,
+                            "example": 20
+                        }
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "検索対象期間（日数）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "maximum": 365,
+                            "minimum": 1,
+                            "example": 30
+                        }
+                    },
+                    {
+                        "name": "min_bookmarks",
+                        "in": "query",
+                        "description": "最小ブックマーク数",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0,
+                            "example": 0
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "検索結果",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "articles": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "properties": {
+                                                            "id": {
+                                                                "type": "integer",
+                                                                "example": 1
+                                                            },
+                                                            "title": {
+                                                                "type": "string",
+                                                                "example": "Laravel入門ガイド"
+                                                            },
+                                                            "url": {
+                                                                "type": "string",
+                                                                "example": "https://qiita.com/sample/items/12345"
+                                                            },
+                                                            "domain": {
+                                                                "type": "string",
+                                                                "example": "qiita.com"
+                                                            },
+                                                            "platform": {
+                                                                "type": "string",
+                                                                "example": "Qiita"
+                                                            },
+                                                            "author_name": {
+                                                                "type": "string",
+                                                                "example": "sample_author"
+                                                            },
+                                                            "author_url": {
+                                                                "type": "string",
+                                                                "example": "https://qiita.com/sample_author"
+                                                            },
+                                                            "published_at": {
+                                                                "type": "string",
+                                                                "format": "date-time"
+                                                            },
+                                                            "bookmark_count": {
+                                                                "type": "integer",
+                                                                "example": 125
+                                                            },
+                                                            "likes_count": {
+                                                                "type": "integer",
+                                                                "example": 45
+                                                            },
+                                                            "match_score": {
+                                                                "type": "number",
+                                                                "format": "float",
+                                                                "example": 0.92
+                                                            },
+                                                            "company": {
+                                                                "type": "object"
+                                                            },
+                                                            "platform_details": {
+                                                                "type": "object"
+                                                            }
+                                                        },
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total_results": {
+                                                    "type": "integer",
+                                                    "example": 15
+                                                },
+                                                "search_time": {
+                                                    "type": "number",
+                                                    "format": "float",
+                                                    "example": 0.089
+                                                },
+                                                "query": {
+                                                    "type": "string",
+                                                    "example": "Laravel"
+                                                },
+                                                "filters": {
+                                                    "properties": {
+                                                        "days": {
+                                                            "type": "integer",
+                                                            "example": 30
+                                                        },
+                                                        "min_bookmarks": {
+                                                            "type": "integer",
+                                                            "example": 0
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "検索クエリが無効です"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/search": {
+            "get": {
+                "tags": [
+                    "検索"
+                ],
+                "summary": "統合検索",
+                "description": "企業・記事を横断的に検索します。",
+                "operationId": "d70c8d72bc43cc6c7321086ae9d2c1f1",
+                "parameters": [
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "description": "検索クエリ（1-255文字）",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "maxLength": 255,
+                            "minLength": 1,
+                            "example": "Laravel"
+                        }
+                    },
+                    {
+                        "name": "type",
+                        "in": "query",
+                        "description": "検索タイプ",
+                        "schema": {
+                            "type": "string",
+                            "default": "all",
+                            "enum": [
+                                "companies",
+                                "articles",
+                                "all"
+                            ],
+                            "example": "all"
+                        }
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "取得件数（最大100）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 20,
+                            "maximum": 100,
+                            "minimum": 1,
+                            "example": 20
+                        }
+                    },
+                    {
+                        "name": "days",
+                        "in": "query",
+                        "description": "記事検索の対象期間（日数）",
+                        "schema": {
+                            "type": "integer",
+                            "default": 30,
+                            "maximum": 365,
+                            "minimum": 1,
+                            "example": 30
+                        }
+                    },
+                    {
+                        "name": "min_bookmarks",
+                        "in": "query",
+                        "description": "記事検索の最小ブックマーク数",
+                        "schema": {
+                            "type": "integer",
+                            "default": 0,
+                            "minimum": 0,
+                            "example": 0
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "検索結果",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "companies": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object"
+                                                    }
+                                                },
+                                                "articles": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "type": "object"
+                                                    }
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "meta": {
+                                            "properties": {
+                                                "total_results": {
+                                                    "type": "integer",
+                                                    "example": 40
+                                                },
+                                                "search_time": {
+                                                    "type": "number",
+                                                    "format": "float",
+                                                    "example": 0.156
+                                                },
+                                                "query": {
+                                                    "type": "string",
+                                                    "example": "Laravel"
+                                                },
+                                                "type": {
+                                                    "type": "string",
+                                                    "example": "all"
+                                                },
+                                                "filters": {
+                                                    "properties": {
+                                                        "days": {
+                                                            "type": "integer",
+                                                            "example": 30
+                                                        },
+                                                        "min_bookmarks": {
+                                                            "type": "integer",
+                                                            "example": 0
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "不正なリクエスト",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "error": {
+                                            "type": "string",
+                                            "example": "検索クエリが無効です"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "企業詳細",
+            "description": "企業の詳細情報、記事一覧、影響力スコア履歴、ランキング情報を提供するAPI"
+        },
+        {
+            "name": "企業ランキング",
+            "description": "企業の技術コミュニティでの影響力ランキングデータを提供するAPI"
+        },
+        {
+            "name": "検索",
+            "description": "企業・記事・技術キーワードを検索するAPI"
+        }
+    ]
+}

--- a/storage/api-docs/api-docs.yaml
+++ b/storage/api-docs/api-docs.yaml
@@ -1,0 +1,1239 @@
+openapi: 3.0.0
+info:
+  title: 'Trends Laravel API'
+  description: 企業の技術コミュニティでの影響力を分析・追跡するAPI
+  contact:
+    email: admin@example.com
+  version: 1.0.0
+servers:
+  -
+    url: 'http://localhost:8000'
+    description: 'API Server'
+paths:
+  '/api/companies/{company_id}':
+    get:
+      tags:
+        - 企業詳細
+      summary: 企業詳細情報取得
+      description: 企業の詳細情報を取得します。現在のランキング情報と最近の記事（最大5件）を含みます。
+      operationId: b87956b293dcfbb97d69bf77d6d496cc
+      parameters:
+        -
+          name: company_id
+          in: path
+          description: 企業ID
+          required: true
+          schema:
+            type: integer
+            example: 1
+      responses:
+        200:
+          description: 企業詳細情報
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      id:
+                        type: integer
+                        example: 1
+                      name:
+                        type: string
+                        example: 'Company A'
+                      domain:
+                        type: string
+                        example: company-a.com
+                      description:
+                        type: string
+                        example: 企業の説明文
+                      logo_url:
+                        type: string
+                        example: 'https://example.com/logo.png'
+                      website_url:
+                        type: string
+                        example: 'https://company-a.com'
+                      is_active:
+                        type: boolean
+                        example: true
+                      current_rankings:
+                        type: array
+                        items:
+                          type: object
+                      recent_articles:
+                        type: array
+                        items:
+                          type: object
+                      created_at:
+                        type: string
+                        format: date-time
+                      updated_at:
+                        type: string
+                        format: date-time
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業IDが無効です
+                  details:
+                    type: object
+                type: object
+        404:
+          description: 企業が見つかりません
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業が見つかりません
+                type: object
+  '/api/companies/{company_id}/articles':
+    get:
+      tags:
+        - 企業詳細
+      summary: 企業の記事一覧取得
+      description: 企業に関連する記事の一覧を取得します。
+      operationId: a6fca0b29fa759399957964775c3bb6f
+      parameters:
+        -
+          name: company_id
+          in: path
+          description: 企業ID
+          required: true
+          schema:
+            type: integer
+            example: 1
+        -
+          name: page
+          in: query
+          description: ページ番号
+          schema:
+            type: integer
+            default: 1
+            example: 1
+        -
+          name: per_page
+          in: query
+          description: 1ページあたりの件数（最大100）
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+            example: 20
+        -
+          name: days
+          in: query
+          description: 過去何日分の記事を取得するか
+          schema:
+            type: integer
+            default: 30
+            example: 30
+        -
+          name: min_bookmarks
+          in: query
+          description: 最小ブックマーク数
+          schema:
+            type: integer
+            default: 0
+            example: 0
+      responses:
+        200:
+          description: 記事一覧
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                  meta:
+                    properties:
+                      current_page:
+                        type: integer
+                      per_page:
+                        type: integer
+                      total:
+                        type: integer
+                      last_page:
+                        type: integer
+                      company_id:
+                        type: integer
+                      filters:
+                        type: object
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業IDが無効です
+                type: object
+        404:
+          description: 企業が見つかりません
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業が見つかりません
+                type: object
+  '/api/companies/{company_id}/scores':
+    get:
+      tags:
+        - 企業詳細
+      summary: 企業の影響力スコア履歴取得
+      description: 企業の影響力スコアの履歴データを取得します。
+      operationId: 30d331d44d5ca7009a0cd5bae88aaf5d
+      parameters:
+        -
+          name: company_id
+          in: path
+          description: 企業ID
+          required: true
+          schema:
+            type: integer
+            example: 1
+        -
+          name: period
+          in: query
+          description: 期間タイプ
+          schema:
+            type: string
+            default: 1d
+            example: 1d
+        -
+          name: days
+          in: query
+          description: 過去何日分のスコアを取得するか
+          schema:
+            type: integer
+            default: 30
+            example: 30
+      responses:
+        200:
+          description: スコア履歴
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      company_id:
+                        type: integer
+                        example: 1
+                      scores:
+                        type: array
+                        items:
+                          properties:
+                            date:
+                              type: string
+                              format: date
+                              example: '2024-01-30'
+                            score:
+                              type: number
+                              format: float
+                              example: 85.5
+                            rank_position:
+                              type: integer
+                              example: 5
+                            calculated_at:
+                              type: string
+                              format: date-time
+                          type: object
+                    type: object
+                  meta:
+                    properties:
+                      period:
+                        type: string
+                      days:
+                        type: integer
+                      total:
+                        type: integer
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業IDが無効です
+                type: object
+        404:
+          description: 企業が見つかりません
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業が見つかりません
+                type: object
+  '/api/companies/{company_id}/rankings':
+    get:
+      tags:
+        - 企業詳細
+      summary: 企業のランキング情報取得
+      description: 企業の各期間でのランキング情報を取得します。
+      operationId: a50a508b0b1a0310be13e75c95aaacfc
+      parameters:
+        -
+          name: company_id
+          in: path
+          description: 企業ID
+          required: true
+          schema:
+            type: integer
+            example: 1
+        -
+          name: include_history
+          in: query
+          description: 履歴を含める
+          schema:
+            type: boolean
+            default: false
+            example: false
+        -
+          name: history_days
+          in: query
+          description: 履歴取得日数
+          schema:
+            type: integer
+            default: 30
+            example: 30
+      responses:
+        200:
+          description: ランキング情報
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      company_id:
+                        type: integer
+                        example: 1
+                      rankings:
+                        type: object
+                      history:
+                        type: array
+                        items:
+                          type: object
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業IDが無効です
+                type: object
+        404:
+          description: 企業が見つかりません
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 企業が見つかりません
+                type: object
+  '/api/rankings/{period}':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 期間別ランキング取得
+      description: 指定した期間の企業ランキングを取得します。
+      operationId: 2a59ef3da07e77296fd7d929cd34076e
+      parameters:
+        -
+          name: period
+          in: path
+          description: '期間タイプ (1w, 1m, 3m, 6m, 1y, 3y, all)'
+          required: true
+          schema:
+            type: string
+            enum:
+              - 1w
+              - 1m
+              - 3m
+              - 6m
+              - 1y
+              - 3y
+              - all
+            example: 1m
+        -
+          name: page
+          in: query
+          description: ページ番号
+          schema:
+            type: integer
+            default: 1
+            example: 1
+        -
+          name: per_page
+          in: query
+          description: 1ページあたりの件数（最大100）
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+            example: 20
+        -
+          name: sort_by
+          in: query
+          description: ソート項目
+          schema:
+            type: string
+            default: rank_position
+            example: rank_position
+        -
+          name: sort_order
+          in: query
+          description: ソート順
+          schema:
+            type: string
+            default: asc
+            enum:
+              - asc
+              - desc
+            example: asc
+      responses:
+        200:
+          description: ランキングリスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                  meta:
+                    properties:
+                      current_page:
+                        type: integer
+                      per_page:
+                        type: integer
+                      total:
+                        type: integer
+                      last_page:
+                        type: integer
+                    type: object
+                type: object
+        400:
+          description: 不正な期間タイプ
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  '/api/rankings/{period}/top/{limit}':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 上位N件のランキング取得
+      description: 指定した期間の上位N件のランキングを取得します。
+      operationId: 78594b53d7fae9a30415e698a61b925f
+      parameters:
+        -
+          name: period
+          in: path
+          description: 期間タイプ
+          required: true
+          schema:
+            type: string
+            enum:
+              - 1w
+              - 1m
+              - 3m
+              - 6m
+              - 1y
+              - 3y
+              - all
+            example: 1m
+        -
+          name: limit
+          in: path
+          description: '取得件数 (1-100)'
+          required: true
+          schema:
+            type: integer
+            maximum: 100
+            minimum: 1
+            example: 10
+      responses:
+        200:
+          description: 上位ランキング
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                  meta:
+                    properties:
+                      period:
+                        type: string
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+                    type: object
+                type: object
+        400:
+          description: 不正なパラメータ
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  '/api/rankings/company/{company_id}':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 特定企業のランキング取得
+      description: 特定企業の全期間ランキング情報を取得します。
+      operationId: e8eb4538d14b415d668f8a5a75aa0201
+      parameters:
+        -
+          name: company_id
+          in: path
+          description: 企業ID
+          required: true
+          schema:
+            type: integer
+            example: 1
+        -
+          name: include_history
+          in: query
+          description: 履歴を含める
+          schema:
+            type: boolean
+            default: false
+            example: false
+        -
+          name: history_days
+          in: query
+          description: 履歴取得日数
+          schema:
+            type: integer
+            default: 30
+            example: 30
+      responses:
+        200:
+          description: 企業ランキング情報
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      company_id:
+                        type: integer
+                      rankings:
+                        type: object
+                      history:
+                        type: object
+                    type: object
+                type: object
+        400:
+          description: 不正な企業ID
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  /api/rankings/statistics:
+    get:
+      tags:
+        - 企業ランキング
+      summary: ランキング統計情報取得
+      description: 全期間のランキング統計情報を取得します。
+      operationId: ebaf8a89cfb807d32cf6da1240d44b60
+      responses:
+        200:
+          description: 統計情報
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      1m:
+                        properties:
+                          total_companies:
+                            type: integer
+                            example: 100
+                          average_score:
+                            type: number
+                            format: float
+                            example: 50.25
+                          max_score:
+                            type: number
+                            format: float
+                            example: 150.75
+                          min_score:
+                            type: number
+                            format: float
+                            example: 5.1
+                          total_articles:
+                            type: integer
+                            example: 1000
+                          total_bookmarks:
+                            type: integer
+                            example: 50000
+                          last_calculated:
+                            type: string
+                            format: date-time
+                        type: object
+                    type: object
+                type: object
+  '/api/rankings/{period}/risers':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 順位上昇企業取得
+      description: 指定した期間で順位が上昇した企業を取得します。
+      operationId: 4291c8cb4bd975a76eb0612b090bc2b3
+      parameters:
+        -
+          name: period
+          in: path
+          description: 期間タイプ
+          required: true
+          schema:
+            type: string
+            enum:
+              - 1w
+              - 1m
+              - 3m
+              - 6m
+              - 1y
+              - 3y
+              - all
+            example: 1m
+        -
+          name: limit
+          in: query
+          description: 取得件数（最大50）
+          schema:
+            type: integer
+            default: 10
+            maximum: 50
+            example: 10
+      responses:
+        200:
+          description: 順位上昇企業リスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      properties:
+                        company_name:
+                          type: string
+                          example: 'Rising Company'
+                        domain:
+                          type: string
+                          example: rising.com
+                        current_rank:
+                          type: integer
+                          example: 5
+                        previous_rank:
+                          type: integer
+                          example: 10
+                        rank_change:
+                          type: integer
+                          example: 5
+                        calculated_at:
+                          type: string
+                          format: date-time
+                      type: object
+                  meta:
+                    properties:
+                      period:
+                        type: string
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+                    type: object
+                type: object
+        400:
+          description: 不正な期間タイプ
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  '/api/rankings/{period}/fallers':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 順位下降企業取得
+      description: 指定した期間で順位が下降した企業を取得します。
+      operationId: 1fd5786a7f0ccdd71c3823e12eca6318
+      parameters:
+        -
+          name: period
+          in: path
+          description: 期間タイプ
+          required: true
+          schema:
+            type: string
+            enum:
+              - 1w
+              - 1m
+              - 3m
+              - 6m
+              - 1y
+              - 3y
+              - all
+            example: 1m
+        -
+          name: limit
+          in: query
+          description: 取得件数（最大50）
+          schema:
+            type: integer
+            default: 10
+            maximum: 50
+            example: 10
+      responses:
+        200:
+          description: 順位下降企業リスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      properties:
+                        company_name:
+                          type: string
+                          example: 'Falling Company'
+                        domain:
+                          type: string
+                          example: falling.com
+                        current_rank:
+                          type: integer
+                          example: 15
+                        previous_rank:
+                          type: integer
+                          example: 8
+                        rank_change:
+                          type: integer
+                          example: -7
+                        calculated_at:
+                          type: string
+                          format: date-time
+                      type: object
+                  meta:
+                    properties:
+                      period:
+                        type: string
+                      limit:
+                        type: integer
+                      total:
+                        type: integer
+                    type: object
+                type: object
+        400:
+          description: 不正な期間タイプ
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  '/api/rankings/{period}/statistics':
+    get:
+      tags:
+        - 企業ランキング
+      summary: 順位変動統計取得
+      description: 指定した期間の順位変動統計情報を取得します。
+      operationId: fec34322cc5c1aa3b37972e5faf38ac5
+      parameters:
+        -
+          name: period
+          in: path
+          description: 期間タイプ
+          required: true
+          schema:
+            type: string
+            enum:
+              - 1w
+              - 1m
+              - 3m
+              - 6m
+              - 1y
+              - 3y
+              - all
+            example: 1m
+      responses:
+        200:
+          description: 順位変動統計
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      total_companies:
+                        type: integer
+                        example: 100
+                      rising_companies:
+                        type: integer
+                        example: 35
+                      falling_companies:
+                        type: integer
+                        example: 40
+                      unchanged_companies:
+                        type: integer
+                        example: 25
+                      average_change:
+                        type: number
+                        format: float
+                        example: 0.8
+                      max_rise:
+                        type: integer
+                        example: 12
+                      max_fall:
+                        type: integer
+                        example: 8
+                      calculated_at:
+                        type: string
+                        format: date-time
+                    type: object
+                type: object
+        400:
+          description: 不正な期間タイプ
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                type: object
+  /api/rankings/periods:
+    get:
+      tags:
+        - 企業ランキング
+      summary: 期間タイプ一覧取得
+      description: 使用可能な期間タイプの一覧を取得します。
+      operationId: 494cd9bbb44db993095cbe91297c21dc
+      responses:
+        200:
+          description: 期間タイプ一覧
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: string
+                      enum:
+                        - 1w
+                        - 1m
+                        - 3m
+                        - 6m
+                        - 1y
+                        - 3y
+                        - all
+                    example:
+                      - 1w
+                      - 1m
+                      - 3m
+                      - 6m
+                      - 1y
+                      - 3y
+                      - all
+                type: object
+  /api/search/companies:
+    get:
+      tags:
+        - 検索
+      summary: 企業検索
+      description: 企業名・ドメイン・説明文から企業を検索します。
+      operationId: 65205532c324c7142beb7954d74d90ba
+      parameters:
+        -
+          name: q
+          in: query
+          description: 検索クエリ（1-255文字）
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+            minLength: 1
+            example: Google
+        -
+          name: limit
+          in: query
+          description: 取得件数（最大100）
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+            minimum: 1
+            example: 20
+      responses:
+        200:
+          description: 検索結果
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      companies:
+                        type: array
+                        items:
+                          properties:
+                            id:
+                              type: integer
+                              example: 1
+                            name:
+                              type: string
+                              example: 株式会社サンプル
+                            domain:
+                              type: string
+                              example: sample.com
+                            description:
+                              type: string
+                              example: サンプル企業の説明
+                            logo_url:
+                              type: string
+                              example: 'https://example.com/logo.png'
+                            website_url:
+                              type: string
+                              example: 'https://sample.com'
+                            is_active:
+                              type: boolean
+                              example: true
+                            match_score:
+                              type: number
+                              format: float
+                              example: 0.95
+                            current_rankings:
+                              type: array
+                              items:
+                                type: object
+                          type: object
+                    type: object
+                  meta:
+                    properties:
+                      total_results:
+                        type: integer
+                        example: 25
+                      search_time:
+                        type: number
+                        format: float
+                        example: 0.123
+                      query:
+                        type: string
+                        example: サンプル
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 検索クエリが無効です
+                  details:
+                    type: object
+                type: object
+  /api/search/articles:
+    get:
+      tags:
+        - 検索
+      summary: 記事検索
+      description: 記事タイトル・著者名から記事を検索します。
+      operationId: fdf80b709ecde3acfef0d13a86558991
+      parameters:
+        -
+          name: q
+          in: query
+          description: 検索クエリ（1-255文字）
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+            minLength: 1
+            example: Laravel
+        -
+          name: limit
+          in: query
+          description: 取得件数（最大100）
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+            minimum: 1
+            example: 20
+        -
+          name: days
+          in: query
+          description: 検索対象期間（日数）
+          schema:
+            type: integer
+            default: 30
+            maximum: 365
+            minimum: 1
+            example: 30
+        -
+          name: min_bookmarks
+          in: query
+          description: 最小ブックマーク数
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            example: 0
+      responses:
+        200:
+          description: 検索結果
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      articles:
+                        type: array
+                        items:
+                          properties:
+                            id:
+                              type: integer
+                              example: 1
+                            title:
+                              type: string
+                              example: Laravel入門ガイド
+                            url:
+                              type: string
+                              example: 'https://qiita.com/sample/items/12345'
+                            domain:
+                              type: string
+                              example: qiita.com
+                            platform:
+                              type: string
+                              example: Qiita
+                            author_name:
+                              type: string
+                              example: sample_author
+                            author_url:
+                              type: string
+                              example: 'https://qiita.com/sample_author'
+                            published_at:
+                              type: string
+                              format: date-time
+                            bookmark_count:
+                              type: integer
+                              example: 125
+                            likes_count:
+                              type: integer
+                              example: 45
+                            match_score:
+                              type: number
+                              format: float
+                              example: 0.92
+                            company:
+                              type: object
+                            platform_details:
+                              type: object
+                          type: object
+                    type: object
+                  meta:
+                    properties:
+                      total_results:
+                        type: integer
+                        example: 15
+                      search_time:
+                        type: number
+                        format: float
+                        example: 0.089
+                      query:
+                        type: string
+                        example: Laravel
+                      filters:
+                        properties:
+                          days:
+                            type: integer
+                            example: 30
+                          min_bookmarks:
+                            type: integer
+                            example: 0
+                        type: object
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 検索クエリが無効です
+                type: object
+  /api/search:
+    get:
+      tags:
+        - 検索
+      summary: 統合検索
+      description: 企業・記事を横断的に検索します。
+      operationId: d70c8d72bc43cc6c7321086ae9d2c1f1
+      parameters:
+        -
+          name: q
+          in: query
+          description: 検索クエリ（1-255文字）
+          required: true
+          schema:
+            type: string
+            maxLength: 255
+            minLength: 1
+            example: Laravel
+        -
+          name: type
+          in: query
+          description: 検索タイプ
+          schema:
+            type: string
+            default: all
+            enum:
+              - companies
+              - articles
+              - all
+            example: all
+        -
+          name: limit
+          in: query
+          description: 取得件数（最大100）
+          schema:
+            type: integer
+            default: 20
+            maximum: 100
+            minimum: 1
+            example: 20
+        -
+          name: days
+          in: query
+          description: 記事検索の対象期間（日数）
+          schema:
+            type: integer
+            default: 30
+            maximum: 365
+            minimum: 1
+            example: 30
+        -
+          name: min_bookmarks
+          in: query
+          description: 記事検索の最小ブックマーク数
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            example: 0
+      responses:
+        200:
+          description: 検索結果
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    properties:
+                      companies:
+                        type: array
+                        items:
+                          type: object
+                      articles:
+                        type: array
+                        items:
+                          type: object
+                    type: object
+                  meta:
+                    properties:
+                      total_results:
+                        type: integer
+                        example: 40
+                      search_time:
+                        type: number
+                        format: float
+                        example: 0.156
+                      query:
+                        type: string
+                        example: Laravel
+                      type:
+                        type: string
+                        example: all
+                      filters:
+                        properties:
+                          days:
+                            type: integer
+                            example: 30
+                          min_bookmarks:
+                            type: integer
+                            example: 0
+                        type: object
+                    type: object
+                type: object
+        400:
+          description: 不正なリクエスト
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    type: string
+                    example: 検索クエリが無効です
+                type: object
+tags:
+  -
+    name: 企業詳細
+    description: 企業の詳細情報、記事一覧、影響力スコア履歴、ランキング情報を提供するAPI
+  -
+    name: 企業ランキング
+    description: 企業の技術コミュニティでの影響力ランキングデータを提供するAPI
+  -
+    name: 検索
+    description: 企業・記事・技術キーワードを検索するAPI


### PR DESCRIPTION
## Summary
- Laravel SwaggerUI パッケージ (darkaonline/l5-swagger) を導入してOpenAPI 3.0仕様書を作成
- 全15エンドポイント（企業詳細API 4個、企業ランキングAPI 8個、検索API 3個）をSwagger化
- `/api/documentation` エンドポイントでSwaggerUIを提供し、対話的なAPI文書を実現

## 実装内容
- ✅ Laravel SwaggerUIパッケージの導入と設定
- ✅ OpenAPI 3.0仕様書 (api-docs.json/yaml) の作成
- ✅ 全APIコントローラーへのOpenAPIアノテーション追加
- ✅ 詳細なパラメータ、レスポンス例、エラーハンドリングの定義
- ✅ SwaggerUIの動作確認とテスト

## 技術詳細
- **パッケージ**: darkaonline/l5-swagger ^9.0
- **OpenAPI仕様**: 3.0.0
- **エンドポイント**: `/api/documentation` でSwaggerUI提供
- **自動生成**: 開発環境では仕様書を自動再生成

## Test plan
- [x] SwaggerUIが `/api/documentation` で正常に表示される
- [x] 全15エンドポイントがSwaggerUIに表示される
- [x] OpenAPI仕様書 (JSON/YAML) が正常に生成される
- [x] 各エンドポイントの詳細情報が適切に定義されている

🤖 Generated with [Claude Code](https://claude.ai/code)