### PR TITLE
ダッシュボードから企業個別ページへの遷移機能追加

### DIFF
--- a/app/Services/CompanyRankingService.php
+++ b/app/Services/CompanyRankingService.php
@@ -165,6 +165,7 @@ class CompanyRankingService
             ->join('companies as c', 'cr.company_id', '=', 'c.id')
             ->select([
                 'cr.rank_position',
+                'c.id as company_id',
                 'c.name as company_name',
                 'c.domain',
                 'c.logo_url',

--- a/resources/js/pages/Dashboard.tsx
+++ b/resources/js/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { Link } from 'react-router-dom';
 import { api } from '../services/api';
 import { RankingStatsResponse, TopCompaniesResponse, QueryKeys } from '../types';
 
@@ -92,9 +93,12 @@ const Dashboard: React.FC = () => {
                                                 </span>
                                             </td>
                                             <td>
-                                                <button className="text-blue-600 hover:text-blue-900 text-sm font-medium">
+                                                <Link 
+                                                    to={`/companies/${company.company.id}`}
+                                                    className="text-blue-600 hover:text-blue-900 text-sm font-medium"
+                                                >
                                                     詳細を見る
-                                                </button>
+                                                </Link>
                                             </td>
                                         </tr>
                                     ))}


### PR DESCRIPTION
## 概要
ダッシュボードの企業ランキング一覧から、企業個別ページに遷移できる機能を追加しました。

## 変更内容
- ダッシュボードの「詳細を見る」ボタンをReact RouterのLinkコンポーネントに変更
- 企業IDを使用してURLパス（/companies/:id）を動的に構築
- 既存のスタイルを維持したまま機能を追加
- **修正**: `companies/null` 問題を解決

## 主な変更ファイル
- `resources/js/pages/Dashboard.tsx`
  - `Link`コンポーネントをインポート
  - 「詳細を見る」ボタンを`Link`コンポーネントに変更
  - 企業IDを使用した動的パス構築

- `app/Services/CompanyRankingService.php`
  - `getRankingForPeriod`メソッドのSELECT文に`company_id`を追加
  - APIレスポンスで企業IDが正しく取得できるよう修正

## 修正された問題
- **修正前**: ダッシュボードのリンクが`companies/null`になる問題
- **修正後**: 正しい企業IDでナビゲーションが動作

## テスト結果
CLAUDE.mdに従った包括的なチェックを実行：
- ✅ `php artisan test` - 全てのPHPテストが通過
- ✅ `vendor/bin/pint --test` - コードスタイルチェック通過
- ✅ `vendor/bin/phpstan analyse --memory-limit=1G` - 静的解析通過
- ✅ `npm test` - 全てのJavaScriptテストが通過
- ✅ `npm run build` - フロントエンドビルド成功

## 確認事項
- [x] ダッシュボードから企業個別ページへの遷移が正常に動作する
- [x] 企業IDが正しく取得され、`companies/null`問題が解決された
- [x] 全てのテストが通過する
- [x] 既存のスタイルが維持される
- [x] CLAUDE.mdの事前チェック手順を完了

## 関連Issue
Closes #100

🤖 Generated with [Claude Code](https://claude.ai/code)