### PR TITLE
記事一覧ページの実装（企業属性表示機能付き）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,16 @@ npx playwright test
 
 #### 3. PR作成前の必須チェック
 **PR作成前に必ず以下をすべて実行し、エラーがないことを確認する：**
+
+##### 3.1 ドキュメント更新の確認
+**変更内容に応じて関連ドキュメントを必ず更新する：**
+- **新機能・API追加**: [開発フロー.md](docs/wiki/開発フロー.md)、[技術スタック.md](docs/wiki/技術スタック.md)
+- **環境設定・コマンド変更**: [開発環境.md](docs/wiki/開発環境.md)、CLAUDE.md
+- **CI/CD変更**: [CI-CD.md](docs/wiki/CI-CD.md)
+- **データベース変更**: [データベース設計.md](docs/wiki/データベース設計.md)
+- **プロジェクト構造変更**: [プロジェクト概要.md](docs/wiki/プロジェクト概要.md)
+
+##### 3.2 テスト・品質チェック実行
 ```bash
 php artisan test && vendor/bin/pint --test && vendor/bin/phpstan analyse --memory-limit=1G && npm test && npm run build && npm run test:e2e
 ```
@@ -70,6 +80,8 @@ php artisan test && vendor/bin/pint --test && vendor/bin/phpstan analyse --memor
 
 #### 5. 基本開発原則
 - **GitHubのissueを作成してからプルリクエストに紐づけて行う**
+- **コード変更時は対応するドキュメントも必ず同時更新する**
+- **ドキュメント更新なしでのPR作成は禁止**
 - 詳細な開発フロー: [開発フロー.md](docs/wiki/開発フロー.md)
 
 ### 開発禁止事項

--- a/app/Http/Controllers/Api/ArticleController.php
+++ b/app/Http/Controllers/Api/ArticleController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use Illuminate\Http\Request;
+
+class ArticleController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = Article::with(['company', 'platform']);
+
+        if ($request->has('company_id')) {
+            $query->where('company_id', $request->company_id);
+        }
+
+        if ($request->has('platform_id')) {
+            $query->where('platform_id', $request->platform_id);
+        }
+
+        if ($request->has('limit')) {
+            $query->limit($request->limit);
+        }
+
+        $articles = $query->orderBy('published_at', 'desc')->paginate(20);
+
+        return response()->json($articles);
+    }
+}

--- a/resources/js/components/App.tsx
+++ b/resources/js/components/App.tsx
@@ -3,6 +3,7 @@ import { Routes, Route } from 'react-router-dom';
 import Layout from './Layout';
 import Dashboard from '../pages/Dashboard';
 import CompanyDetail from '../pages/CompanyDetail';
+import ArticleList from '../pages/ArticleList';
 
 const App: React.FC = () => {
     return (
@@ -10,6 +11,7 @@ const App: React.FC = () => {
             <Routes>
                 <Route path="/" element={<Dashboard />} />
                 <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/articles" element={<ArticleList />} />
                 <Route path="/companies/:id" element={<CompanyDetail />} />
             </Routes>
         </Layout>

--- a/resources/js/components/Sidebar.tsx
+++ b/resources/js/components/Sidebar.tsx
@@ -8,6 +8,7 @@ const Sidebar: React.FC = () => {
         { name: 'ダッシュボード', href: '/', current: location.pathname === '/' },
         { name: 'ランキング', href: '/rankings', current: location.pathname === '/rankings' },
         { name: '企業一覧', href: '/companies', current: location.pathname === '/companies' },
+        { name: '記事一覧', href: '/articles', current: location.pathname === '/articles' },
         { name: '検索', href: '/search', current: location.pathname === '/search' },
     ];
 

--- a/resources/js/components/__tests__/InfluenceChart.test.tsx
+++ b/resources/js/components/__tests__/InfluenceChart.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import InfluenceChart from '../InfluenceChart';
-import { InfluenceChartData } from '../../types/index';
+import { InfluenceChartData, MockChartProps } from '../../types/index';
 
 // Chart.jsのモック
 vi.mock('react-chartjs-2', () => ({
-    Line: ({ data, options, ...props }: any) => (
+    Line: ({ data, options, ...props }: MockChartProps) => (
         <div data-testid="line-chart" {...props}>
             <div data-testid="chart-data">{JSON.stringify(data)}</div>
             <div data-testid="chart-options">{JSON.stringify(options)}</div>

--- a/resources/js/components/__tests__/RankingHistoryChart.test.tsx
+++ b/resources/js/components/__tests__/RankingHistoryChart.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import RankingHistoryChart from '../RankingHistoryChart';
-import { RankingHistoryData } from '../../types/index';
+import { RankingHistoryData, MockChartProps } from '../../types/index';
 
 // Chart.jsのモック
 vi.mock('react-chartjs-2', () => ({
-    Line: ({ data, options, ...props }: any) => (
+    Line: ({ data, options, ...props }: MockChartProps) => (
         <div data-testid="line-chart" {...props}>
             <div data-testid="chart-data">{JSON.stringify(data)}</div>
             <div data-testid="chart-options">{JSON.stringify(options)}</div>

--- a/resources/js/components/__tests__/TrendChart.test.tsx
+++ b/resources/js/components/__tests__/TrendChart.test.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import TrendChart from '../TrendChart';
-import { TrendChartData } from '../../types/index';
+import { TrendChartData, MockChartProps } from '../../types/index';
 
 // Chart.jsのモック
 vi.mock('react-chartjs-2', () => ({
-    Bar: ({ data, options, ...props }: any) => (
+    Bar: ({ data, options, ...props }: MockChartProps) => (
         <div data-testid="bar-chart" {...props}>
             <div data-testid="chart-data">{JSON.stringify(data)}</div>
             <div data-testid="chart-options">{JSON.stringify(options)}</div>

--- a/resources/js/pages/ArticleList.tsx
+++ b/resources/js/pages/ArticleList.tsx
@@ -20,7 +20,7 @@ interface Article {
     author_name?: string;
     published_at: string;
     bookmark_count: number;
-    company: Company;
+    company: Company | null;
     platform: Platform;
 }
 
@@ -122,7 +122,7 @@ const ArticleList: React.FC = () => {
                                                 <div className="mt-2 flex items-center text-sm text-gray-500">
                                                     <div className="flex items-center space-x-4">
                                                         <div className="flex items-center space-x-2">
-                                                            {article.company.logo_url && (
+                                                            {article.company?.logo_url && (
                                                                 <img
                                                                     src={article.company.logo_url}
                                                                     alt={article.company.name}
@@ -130,7 +130,7 @@ const ArticleList: React.FC = () => {
                                                                 />
                                                             )}
                                                             <span className="font-medium text-gray-900">
-                                                                {article.company.name}
+                                                                {article.company?.name || '不明な企業'}
                                                             </span>
                                                         </div>
                                                         <span className="text-gray-300">•</span>

--- a/resources/js/pages/ArticleList.tsx
+++ b/resources/js/pages/ArticleList.tsx
@@ -1,0 +1,253 @@
+import React, { useState, useEffect } from 'react';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+
+interface Company {
+    id: number;
+    name: string;
+    domain: string;
+    logo_url?: string;
+}
+
+interface Platform {
+    id: number;
+    name: string;
+}
+
+interface Article {
+    id: number;
+    title: string;
+    url: string;
+    author_name?: string;
+    published_at: string;
+    bookmark_count: number;
+    company: Company;
+    platform: Platform;
+}
+
+interface PaginationData {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    data: Article[];
+}
+
+const ArticleList: React.FC = () => {
+    const [articles, setArticles] = useState<PaginationData | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [currentPage, setCurrentPage] = useState(1);
+
+    useEffect(() => {
+        fetchArticles(currentPage);
+    }, [currentPage]);
+
+    const fetchArticles = async (page: number) => {
+        try {
+            setLoading(true);
+            const response = await fetch(`/api/articles?page=${page}`);
+            if (!response.ok) {
+                throw new Error('記事の取得に失敗しました');
+            }
+            const data = await response.json();
+            setArticles(data);
+            setError(null);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : '不明なエラーが発生しました');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const formatDate = (dateString: string) => {
+        return new Date(dateString).toLocaleDateString('ja-JP', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
+        });
+    };
+
+    if (loading) {
+        return (
+            <div className="flex justify-center items-center h-64">
+                <div className="text-center">
+                    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-blue-600 mx-auto"></div>
+                    <p className="mt-4 text-gray-600">読み込み中...</p>
+                </div>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="bg-red-50 border border-red-200 rounded-md p-4">
+                <div className="flex">
+                    <div className="ml-3">
+                        <h3 className="text-sm font-medium text-red-800">エラー</h3>
+                        <div className="mt-2 text-sm text-red-700">{error}</div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-6">
+            <div className="sm:flex sm:items-center">
+                <div className="sm:flex-auto">
+                    <h1 className="text-2xl font-semibold text-gray-900">記事一覧</h1>
+                    <p className="mt-2 text-sm text-gray-700">
+                        企業別の技術記事を確認できます。
+                    </p>
+                </div>
+            </div>
+
+            {articles && (
+                <>
+                    <div className="bg-white shadow overflow-hidden sm:rounded-md">
+                        <ul role="list" className="divide-y divide-gray-200">
+                            {articles.data.map((article) => (
+                                <li key={article.id}>
+                                    <a
+                                        href={article.url}
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        className="block hover:bg-gray-50 px-4 py-4 sm:px-6"
+                                    >
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex-1 min-w-0">
+                                                <p className="text-sm font-medium text-gray-900 truncate">
+                                                    {article.title}
+                                                </p>
+                                                <div className="mt-2 flex items-center text-sm text-gray-500">
+                                                    <div className="flex items-center space-x-4">
+                                                        <div className="flex items-center space-x-2">
+                                                            {article.company.logo_url && (
+                                                                <img
+                                                                    src={article.company.logo_url}
+                                                                    alt={article.company.name}
+                                                                    className="h-5 w-5 rounded-full"
+                                                                />
+                                                            )}
+                                                            <span className="font-medium text-gray-900">
+                                                                {article.company.name}
+                                                            </span>
+                                                        </div>
+                                                        <span className="text-gray-300">•</span>
+                                                        <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
+                                                            {article.platform.name}
+                                                        </span>
+                                                        {article.author_name && (
+                                                            <>
+                                                                <span className="text-gray-300">•</span>
+                                                                <span>{article.author_name}</span>
+                                                            </>
+                                                        )}
+                                                        <span className="text-gray-300">•</span>
+                                                        <span>{formatDate(article.published_at)}</span>
+                                                        {article.bookmark_count > 0 && (
+                                                            <>
+                                                                <span className="text-gray-300">•</span>
+                                                                <span className="text-green-600">
+                                                                    {article.bookmark_count} ブックマーク
+                                                                </span>
+                                                            </>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div className="ml-5 flex-shrink-0">
+                                                <ChevronRightIcon className="h-5 w-5 text-gray-400" />
+                                            </div>
+                                        </div>
+                                    </a>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+
+                    {articles.last_page > 1 && (
+                        <div className="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+                            <div className="flex-1 flex justify-between sm:hidden">
+                                <button
+                                    onClick={() => setCurrentPage(currentPage - 1)}
+                                    disabled={currentPage === 1}
+                                    className="relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    前へ
+                                </button>
+                                <button
+                                    onClick={() => setCurrentPage(currentPage + 1)}
+                                    disabled={currentPage === articles.last_page}
+                                    className="ml-3 relative inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                                >
+                                    次へ
+                                </button>
+                            </div>
+                            <div className="hidden sm:flex-1 sm:flex sm:items-center sm:justify-between">
+                                <div>
+                                    <p className="text-sm text-gray-700">
+                                        <span className="font-medium">{articles.total}</span> 件中{' '}
+                                        <span className="font-medium">
+                                            {(articles.current_page - 1) * articles.per_page + 1}
+                                        </span>{' '}
+                                        -{' '}
+                                        <span className="font-medium">
+                                            {Math.min(articles.current_page * articles.per_page, articles.total)}
+                                        </span>{' '}
+                                        件を表示
+                                    </p>
+                                </div>
+                                <div>
+                                    <nav className="relative z-0 inline-flex rounded-md shadow-sm -space-x-px">
+                                        <button
+                                            onClick={() => setCurrentPage(currentPage - 1)}
+                                            disabled={currentPage === 1}
+                                            className="relative inline-flex items-center px-2 py-2 rounded-l-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            前へ
+                                        </button>
+                                        {Array.from({ length: articles.last_page }, (_, i) => i + 1)
+                                            .filter(page => 
+                                                page === 1 || 
+                                                page === articles.last_page || 
+                                                Math.abs(page - currentPage) <= 2
+                                            )
+                                            .map((page, index, array) => (
+                                                <React.Fragment key={page}>
+                                                    {index > 0 && array[index - 1] !== page - 1 && (
+                                                        <span className="relative inline-flex items-center px-4 py-2 border border-gray-300 bg-white text-sm font-medium text-gray-700">
+                                                            ...
+                                                        </span>
+                                                    )}
+                                                    <button
+                                                        onClick={() => setCurrentPage(page)}
+                                                        className={`relative inline-flex items-center px-4 py-2 border text-sm font-medium ${
+                                                            page === currentPage
+                                                                ? 'z-10 bg-blue-50 border-blue-500 text-blue-600'
+                                                                : 'bg-white border-gray-300 text-gray-500 hover:bg-gray-50'
+                                                        }`}
+                                                    >
+                                                        {page}
+                                                    </button>
+                                                </React.Fragment>
+                                            ))}
+                                        <button
+                                            onClick={() => setCurrentPage(currentPage + 1)}
+                                            disabled={currentPage === articles.last_page}
+                                            className="relative inline-flex items-center px-2 py-2 rounded-r-md border border-gray-300 bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                                        >
+                                            次へ
+                                        </button>
+                                    </nav>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+};
+
+export default ArticleList;

--- a/resources/js/pages/ArticleList.tsx
+++ b/resources/js/pages/ArticleList.tsx
@@ -1,36 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
-
-interface Company {
-    id: number;
-    name: string;
-    domain: string;
-    logo_url?: string;
-}
-
-interface Platform {
-    id: number;
-    name: string;
-}
-
-interface Article {
-    id: number;
-    title: string;
-    url: string;
-    author_name?: string;
-    published_at: string;
-    bookmark_count: number;
-    company: Company | null;
-    platform: Platform;
-}
-
-interface PaginationData {
-    current_page: number;
-    last_page: number;
-    per_page: number;
-    total: number;
-    data: Article[];
-}
+import { Article, Company, Platform, PaginationData } from '../types';
 
 const ArticleList: React.FC = () => {
     const [articles, setArticles] = useState<PaginationData | null>(null);

--- a/resources/js/pages/__tests__/ArticleList.test.tsx
+++ b/resources/js/pages/__tests__/ArticleList.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import ArticleList from '../ArticleList';
-import { Article, Company, Platform, PaginationData } from '../../types';
+import { Article, Company, Platform, PaginationData, MockFetch } from '../../types';
 
 const mockArticles: PaginationData = {
     data: [
@@ -61,7 +61,7 @@ const mockArticles: PaginationData = {
 };
 
 beforeEach(() => {
-    global.fetch = vi.fn();
+    global.fetch = vi.fn() as MockFetch;
 });
 
 afterEach(() => {
@@ -78,7 +78,7 @@ const renderArticleList = () => {
 
 describe('ArticleList', () => {
     it('記事一覧が正しく表示される', async () => {
-        (global.fetch as any).mockResolvedValueOnce({
+        (global.fetch as MockFetch).mockResolvedValueOnce({
             ok: true,
             json: async () => mockArticles,
         });
@@ -97,7 +97,7 @@ describe('ArticleList', () => {
     });
 
     it('企業のロゴが表示される', async () => {
-        (global.fetch as any).mockResolvedValueOnce({
+        (global.fetch as MockFetch).mockResolvedValueOnce({
             ok: true,
             json: async () => mockArticles,
         });
@@ -114,7 +114,7 @@ describe('ArticleList', () => {
     });
 
     it('ブックマーク数が表示される', async () => {
-        (global.fetch as any).mockResolvedValueOnce({
+        (global.fetch as MockFetch).mockResolvedValueOnce({
             ok: true,
             json: async () => mockArticles,
         });
@@ -130,7 +130,7 @@ describe('ArticleList', () => {
     });
 
     it('記事のリンクが正しく設定される', async () => {
-        (global.fetch as any).mockResolvedValueOnce({
+        (global.fetch as MockFetch).mockResolvedValueOnce({
             ok: true,
             json: async () => mockArticles,
         });
@@ -151,7 +151,7 @@ describe('ArticleList', () => {
     });
 
     it('ローディング状態が表示される', () => {
-        (global.fetch as any).mockImplementationOnce(
+        (global.fetch as MockFetch).mockImplementationOnce(
             () => new Promise(() => {}) // 永続的にpending状態
         );
 
@@ -161,7 +161,7 @@ describe('ArticleList', () => {
     });
 
     it('エラー状態が表示される', async () => {
-        (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+        (global.fetch as MockFetch).mockRejectedValueOnce(new Error('Network error'));
 
         renderArticleList();
 
@@ -173,7 +173,7 @@ describe('ArticleList', () => {
     });
 
     it('記事が見つからない場合のメッセージが表示される', async () => {
-        (global.fetch as any).mockResolvedValueOnce({
+        (global.fetch as MockFetch).mockResolvedValueOnce({
             ok: true,
             json: async () => ({
                 data: [],

--- a/resources/js/pages/__tests__/ArticleList.test.tsx
+++ b/resources/js/pages/__tests__/ArticleList.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import ArticleList from '../ArticleList';
+
+const mockArticles = {
+    data: [
+        {
+            id: 1,
+            title: 'Test Article 1',
+            url: 'https://example.com/article1',
+            author_name: 'Test Author',
+            published_at: '2023-01-01T00:00:00Z',
+            bookmark_count: 10,
+            company: {
+                id: 1,
+                name: 'Test Company',
+                domain: 'example.com',
+                logo_url: 'https://example.com/logo.png',
+            },
+            platform: {
+                id: 1,
+                name: 'Test Platform',
+            },
+        },
+        {
+            id: 2,
+            title: 'Test Article 2',
+            url: 'https://example.com/article2',
+            author_name: 'Test Author 2',
+            published_at: '2023-01-02T00:00:00Z',
+            bookmark_count: 5,
+            company: {
+                id: 2,
+                name: 'Test Company 2',
+                domain: 'example2.com',
+                logo_url: null,
+            },
+            platform: {
+                id: 1,
+                name: 'Test Platform',
+            },
+        },
+    ],
+    current_page: 1,
+    last_page: 1,
+    per_page: 20,
+    total: 2,
+};
+
+beforeEach(() => {
+    global.fetch = vi.fn();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+const renderArticleList = () => {
+    return render(
+        <BrowserRouter>
+            <ArticleList />
+        </BrowserRouter>
+    );
+};
+
+describe('ArticleList', () => {
+    it('記事一覧が正しく表示される', async () => {
+        (global.fetch as any).mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockArticles,
+        });
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('記事一覧')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Test Article 1')).toBeInTheDocument();
+        expect(screen.getByText('Test Article 2')).toBeInTheDocument();
+        expect(screen.getByText('Test Company')).toBeInTheDocument();
+        expect(screen.getByText('Test Company 2')).toBeInTheDocument();
+        expect(screen.getAllByText('Test Platform')).toHaveLength(2);
+    });
+
+    it('企業のロゴが表示される', async () => {
+        (global.fetch as any).mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockArticles,
+        });
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('記事一覧')).toBeInTheDocument();
+        });
+
+        const logo = screen.getByAltText('Test Company');
+        expect(logo).toBeInTheDocument();
+        expect(logo).toHaveAttribute('src', 'https://example.com/logo.png');
+    });
+
+    it('ブックマーク数が表示される', async () => {
+        (global.fetch as any).mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockArticles,
+        });
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('記事一覧')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('10 ブックマーク')).toBeInTheDocument();
+        expect(screen.getByText('5 ブックマーク')).toBeInTheDocument();
+    });
+
+    it('記事のリンクが正しく設定される', async () => {
+        (global.fetch as any).mockResolvedValueOnce({
+            ok: true,
+            json: async () => mockArticles,
+        });
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('記事一覧')).toBeInTheDocument();
+        });
+
+        const link1 = screen.getByText('Test Article 1').closest('a');
+        const link2 = screen.getByText('Test Article 2').closest('a');
+
+        expect(link1).toHaveAttribute('href', 'https://example.com/article1');
+        expect(link1).toHaveAttribute('target', '_blank');
+        expect(link2).toHaveAttribute('href', 'https://example.com/article2');
+        expect(link2).toHaveAttribute('target', '_blank');
+    });
+
+    it('ローディング状態が表示される', () => {
+        (global.fetch as any).mockImplementationOnce(
+            () => new Promise(() => {}) // 永続的にpending状態
+        );
+
+        renderArticleList();
+
+        expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    });
+
+    it('エラー状態が表示される', async () => {
+        (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('エラー')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    it('記事が見つからない場合のメッセージが表示される', async () => {
+        (global.fetch as any).mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                data: [],
+                current_page: 1,
+                last_page: 1,
+                per_page: 20,
+                total: 0,
+            }),
+        });
+
+        renderArticleList();
+
+        await waitFor(() => {
+            expect(screen.getByText('記事一覧')).toBeInTheDocument();
+        });
+
+        // 記事が0件の場合、記事一覧は表示されているが中身は空
+        expect(screen.getByText('記事一覧')).toBeInTheDocument();
+    });
+});

--- a/resources/js/pages/__tests__/ArticleList.test.tsx
+++ b/resources/js/pages/__tests__/ArticleList.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import { vi } from 'vitest';
 import ArticleList from '../ArticleList';
+import { Article, Company, Platform, PaginationData } from '../../types';
 
-const mockArticles = {
+const mockArticles: PaginationData = {
     data: [
         {
             id: 1,
@@ -18,11 +19,16 @@ const mockArticles = {
                 name: 'Test Company',
                 domain: 'example.com',
                 logo_url: 'https://example.com/logo.png',
+                created_at: '2023-01-01T00:00:00Z',
+                updated_at: '2023-01-01T00:00:00Z',
             },
             platform: {
                 id: 1,
                 name: 'Test Platform',
             },
+            platform_id: 1,
+            created_at: '2023-01-01T00:00:00Z',
+            updated_at: '2023-01-01T00:00:00Z',
         },
         {
             id: 2,
@@ -35,12 +41,17 @@ const mockArticles = {
                 id: 2,
                 name: 'Test Company 2',
                 domain: 'example2.com',
-                logo_url: null,
+                logo_url: undefined,
+                created_at: '2023-01-02T00:00:00Z',
+                updated_at: '2023-01-02T00:00:00Z',
             },
             platform: {
                 id: 1,
                 name: 'Test Platform',
             },
+            platform_id: 1,
+            created_at: '2023-01-02T00:00:00Z',
+            updated_at: '2023-01-02T00:00:00Z',
         },
     ],
     current_page: 1,

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -2,30 +2,50 @@
 export interface Company {
     id: number;
     name: string;
+    domain: string;
     description?: string;
+    logo_url?: string;
+    website_url?: string;
     website?: string;
     hatena_username?: string;
     qiita_username?: string;
     zenn_username?: string;
     influence_score?: number;
     ranking?: number;
+    is_active?: boolean;
     created_at: string;
     updated_at: string;
+}
+
+export interface Platform {
+    id: number;
+    name: string;
+    base_url?: string;
+    is_active?: boolean;
+    created_at?: string;
+    updated_at?: string;
 }
 
 export interface Article {
     id: number;
     title: string;
     url: string;
+    author_name?: string;
     published_at: string;
     bookmark_count: number;
-    like_count: number;
-    view_count: number;
-    company_id: number;
-    platform: string;
+    likes_count?: number;
+    like_count?: number;
+    view_count?: number;
+    company_id?: number;
+    platform_id?: number;
+    platform: Platform;
+    domain?: string;
+    author?: string;
+    author_url?: string;
+    scraped_at?: string;
     created_at: string;
     updated_at: string;
-    company?: Company;
+    company: Company | null;
 }
 
 export interface CompanyRanking {
@@ -131,12 +151,27 @@ export interface PaginatedResponse<T> {
     last_page: number;
     per_page: number;
     total: number;
-    links?: {
-        first?: string;
-        last?: string;
-        prev?: string;
-        next?: string;
-    };
+    from?: number;
+    to?: number;
+    first_page_url?: string;
+    last_page_url?: string;
+    next_page_url?: string;
+    prev_page_url?: string;
+    path?: string;
+    links?: Array<{
+        url: string | null;
+        label: string;
+        active: boolean;
+    }>;
+}
+
+// 記事一覧専用のページネーション型（後方互換性のため）
+export interface PaginationData {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    data: Article[];
 }
 
 // フォーム関連型定義

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -299,3 +299,23 @@ export const QueryKeys = {
     TREND_CHART: (period: string) => ['trend-chart', period] as const,
     RANKING_HISTORY: (companyId: number, period: string) => ['ranking-history', companyId, period] as const,
 } as const;
+
+// テスト用の型定義
+export interface MockResponse {
+    ok: boolean;
+    json: () => Promise<PaginationData | ApiError>;
+}
+
+export interface MockFetch {
+    (url: string, options?: RequestInit): Promise<MockResponse>;
+    mockResolvedValueOnce: (value: MockResponse) => MockFetch;
+    mockRejectedValueOnce: (error: Error) => MockFetch;
+    mockImplementationOnce: (fn: () => Promise<MockResponse>) => MockFetch;
+}
+
+// Chart.js テスト用の型定義
+export interface MockChartProps {
+    data: ChartDataPoint[] | TimeSeriesData[] | TrendChartData | InfluenceChartData[] | RankingHistoryData[];
+    options?: ChartConfig;
+    [key: string]: unknown;
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -59,6 +59,12 @@ Route::middleware(['throttle:60,1'])->group(function () {
         Route::get('{company_id}/rankings', [CompanyController::class, 'rankings']);
     });
 
+    // 記事 API
+    Route::prefix('articles')->group(function () {
+        // 記事一覧
+        Route::get('', [App\Http\Controllers\Api\ArticleController::class, 'index']);
+    });
+
     // 検索 API
     Route::prefix('search')->group(function () {
         // 企業検索

--- a/tests/Feature/Api/ArticleControllerTest.php
+++ b/tests/Feature/Api/ArticleControllerTest.php
@@ -53,7 +53,7 @@ class ArticleControllerTest extends TestCase
             ]);
     }
 
-    public function test_企業_i_dでフィルタリングできること()
+    public function test_企業idでフィルタリングできること()
     {
         $company1 = Company::factory()->create();
         $company2 = Company::factory()->create();
@@ -79,7 +79,7 @@ class ArticleControllerTest extends TestCase
         }
     }
 
-    public function test_プラットフォーム_i_dでフィルタリングできること()
+    public function test_プラットフォームidでフィルタリングできること()
     {
         $company = Company::factory()->create();
         $platform1 = Platform::factory()->create();

--- a/tests/Feature/Api/ArticleControllerTest.php
+++ b/tests/Feature/Api/ArticleControllerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Article;
+use App\Models\Company;
+use App\Models\Platform;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ArticleControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_記事一覧が取得できること()
+    {
+        $company = Company::factory()->create();
+        $platform = Platform::factory()->create();
+
+        Article::factory()->count(5)->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform->id,
+        ]);
+
+        $response = $this->getJson('/api/articles');
+
+        $response->assertStatus(200)
+            ->assertJsonStructure([
+                'data' => [
+                    '*' => [
+                        'id',
+                        'title',
+                        'url',
+                        'author_name',
+                        'published_at',
+                        'bookmark_count',
+                        'company' => [
+                            'id',
+                            'name',
+                            'domain',
+                            'logo_url',
+                        ],
+                        'platform' => [
+                            'id',
+                            'name',
+                        ],
+                    ],
+                ],
+                'current_page',
+                'last_page',
+                'per_page',
+                'total',
+            ]);
+    }
+
+    public function test_企業_i_dでフィルタリングできること()
+    {
+        $company1 = Company::factory()->create();
+        $company2 = Company::factory()->create();
+        $platform = Platform::factory()->create();
+
+        Article::factory()->count(3)->create([
+            'company_id' => $company1->id,
+            'platform_id' => $platform->id,
+        ]);
+
+        Article::factory()->count(2)->create([
+            'company_id' => $company2->id,
+            'platform_id' => $platform->id,
+        ]);
+
+        $response = $this->getJson("/api/articles?company_id={$company1->id}");
+
+        $response->assertStatus(200);
+        $this->assertCount(3, $response->json('data'));
+
+        foreach ($response->json('data') as $article) {
+            $this->assertEquals($company1->id, $article['company']['id']);
+        }
+    }
+
+    public function test_プラットフォーム_i_dでフィルタリングできること()
+    {
+        $company = Company::factory()->create();
+        $platform1 = Platform::factory()->create();
+        $platform2 = Platform::factory()->create();
+
+        Article::factory()->count(3)->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform1->id,
+        ]);
+
+        Article::factory()->count(2)->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform2->id,
+        ]);
+
+        $response = $this->getJson("/api/articles?platform_id={$platform1->id}");
+
+        $response->assertStatus(200);
+        $this->assertCount(3, $response->json('data'));
+
+        foreach ($response->json('data') as $article) {
+            $this->assertEquals($platform1->id, $article['platform']['id']);
+        }
+    }
+
+    public function test_記事が日付順でソートされていること()
+    {
+        $company = Company::factory()->create();
+        $platform = Platform::factory()->create();
+
+        $article1 = Article::factory()->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform->id,
+            'published_at' => now()->subDays(3),
+        ]);
+
+        $article2 = Article::factory()->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform->id,
+            'published_at' => now()->subDays(1),
+        ]);
+
+        $article3 = Article::factory()->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform->id,
+            'published_at' => now()->subDays(2),
+        ]);
+
+        $response = $this->getJson('/api/articles');
+
+        $response->assertStatus(200);
+        $articles = $response->json('data');
+
+        $this->assertEquals($article2->id, $articles[0]['id']);
+        $this->assertEquals($article3->id, $articles[1]['id']);
+        $this->assertEquals($article1->id, $articles[2]['id']);
+    }
+
+    public function test_ページネーションが正しく動作すること()
+    {
+        $company = Company::factory()->create();
+        $platform = Platform::factory()->create();
+
+        Article::factory()->count(25)->create([
+            'company_id' => $company->id,
+            'platform_id' => $platform->id,
+        ]);
+
+        $response = $this->getJson('/api/articles');
+
+        $response->assertStatus(200);
+        $this->assertCount(20, $response->json('data'));
+        $this->assertEquals(25, $response->json('total'));
+        $this->assertEquals(2, $response->json('last_page'));
+    }
+}

--- a/tests/Feature/CompanyRankingApiTest.php
+++ b/tests/Feature/CompanyRankingApiTest.php
@@ -199,7 +199,7 @@ class CompanyRankingApiTest extends TestCase
             ]);
     }
 
-    public function test_無効な企業_i_dでランキング取得するとエラーが返る()
+    public function test_無効な企業idでランキング取得するとエラーが返る()
     {
         $response = $this->getJson('/api/rankings/company/99999');
 

--- a/tests/e2e/article-list.spec.ts
+++ b/tests/e2e/article-list.spec.ts
@@ -1,0 +1,285 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('記事一覧ページ', () => {
+  test('記事一覧ページが正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    
+    // ページタイトルが正しく設定されている
+    await expect(page).toHaveTitle(/DevCorpTrends/);
+    
+    // ページが完全にロードされるまで待機
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のヘッダーが表示されている
+    await expect(page.locator('h1')).toContainText('記事一覧');
+    
+    // 説明文が表示されている
+    await expect(page.locator('p').first()).toContainText('企業別の技術記事を確認できます');
+  });
+
+  test('記事データが正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    // 記事アイテムが表示されている
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // 最初の記事要素をチェック
+      const firstArticle = articles.first();
+      await expect(firstArticle).toBeVisible();
+      
+      // 記事タイトルが表示されている
+      const titleLink = firstArticle.locator('a');
+      await expect(titleLink).toBeVisible();
+      
+      // 企業名が表示されている
+      const companyName = firstArticle.locator('text=/[^•]+/');
+      await expect(companyName.first()).toBeVisible();
+      
+      // プラットフォームバッジが表示されている
+      const platformBadge = firstArticle.locator('.bg-blue-100');
+      await expect(platformBadge).toBeVisible();
+    }
+  });
+
+  test('記事のリンクが正常に動作する', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // 最初の記事リンクをチェック
+      const firstArticleLink = articles.first().locator('a');
+      await expect(firstArticleLink).toBeVisible();
+      
+      // リンクが外部サイトを指している
+      const href = await firstArticleLink.getAttribute('href');
+      expect(href).toBeTruthy();
+      expect(href).toMatch(/^https?:\/\//);
+      
+      // target="_blank"が設定されている
+      const target = await firstArticleLink.getAttribute('target');
+      expect(target).toBe('_blank');
+    }
+  });
+
+  test('企業ロゴが正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // 企業ロゴが存在する記事を探す
+      const logoImages = page.locator('[role="list"] img');
+      const logoCount = await logoImages.count();
+      
+      if (logoCount > 0) {
+        const firstLogo = logoImages.first();
+        await expect(firstLogo).toBeVisible();
+        
+        // ロゴのaltテキストが設定されている
+        const alt = await firstLogo.getAttribute('alt');
+        expect(alt).toBeTruthy();
+        expect(alt).not.toBe('');
+      }
+    }
+  });
+
+  test('ページネーションが正常に動作する', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    // ページネーションが存在するかチェック
+    const pagination = page.locator('nav[class*="pagination"], .pagination, nav:has(button:text("次へ"))');
+    const paginationExists = await pagination.count() > 0;
+    
+    if (paginationExists) {
+      // 次へボタンが存在する場合 - デスクトップ版を対象
+      const nextButton = page.locator('button:text("次へ")').last();
+      const nextButtonExists = await nextButton.count() > 0;
+      
+      if (nextButtonExists) {
+        // ボタンがvisibleかつenabledかチェック
+        const isVisible = await nextButton.isVisible();
+        const isEnabled = await nextButton.isEnabled();
+        
+        if (isVisible && isEnabled) {
+          // 次のページに移動
+          await nextButton.click();
+          await page.waitForLoadState('networkidle');
+          
+          // 前へボタンが表示されていることを確認
+          const prevButton = page.locator('button:text("前へ")').last();
+          await expect(prevButton).toBeVisible();
+          await expect(prevButton).toBeEnabled();
+        }
+      }
+      
+      // ページ情報が表示されている
+      const pageInfo = page.locator('text=/件中.*件を表示/');
+      if (await pageInfo.count() > 0) {
+        await expect(pageInfo.first()).toBeVisible();
+      }
+    }
+  });
+
+  test('ブックマーク数が正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // ブックマーク数が表示されている記事を探す
+      const bookmarkCounts = page.locator('text=/\\d+ ブックマーク/');
+      const bookmarkCount = await bookmarkCounts.count();
+      
+      if (bookmarkCount > 0) {
+        const firstBookmark = bookmarkCounts.first();
+        await expect(firstBookmark).toBeVisible();
+        
+        // ブックマーク数が0以上であることを確認
+        const text = await firstBookmark.textContent();
+        expect(text).toMatch(/\d+ ブックマーク/);
+      }
+    }
+  });
+
+  test('企業名が正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // 企業名が表示されているかチェック
+      const companyNames = page.locator('.font-medium.text-gray-900');
+      const companyCount = await companyNames.count();
+      
+      if (companyCount > 0) {
+        const firstCompany = companyNames.first();
+        await expect(firstCompany).toBeVisible();
+        
+        // 企業名が空でないことを確認
+        const text = await firstCompany.textContent();
+        expect(text).toBeTruthy();
+        expect(text?.trim()).not.toBe('');
+      }
+    }
+  });
+
+  test('プラットフォームバッジが正常に表示される', async ({ page }) => {
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('[role="list"]', { timeout: 10000 });
+    
+    const articles = page.locator('[role="list"] li');
+    const count = await articles.count();
+    
+    if (count > 0) {
+      // プラットフォームバッジが表示されているかチェック
+      const platformBadges = page.locator('.bg-blue-100.text-blue-800');
+      const badgeCount = await platformBadges.count();
+      
+      if (badgeCount > 0) {
+        const firstBadge = platformBadges.first();
+        await expect(firstBadge).toBeVisible();
+        
+        // プラットフォーム名が表示されているかチェック
+        const text = await firstBadge.textContent();
+        expect(text).toBeTruthy();
+        expect(text?.trim()).not.toBe('');
+      }
+    }
+  });
+
+  test('記事一覧が空の場合の処理', async ({ page }) => {
+    // 空の記事一覧をシミュレート（実際のAPIから空のデータが返される場合）
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('h1', { timeout: 10000 });
+    
+    // ヘッダーは表示されている
+    await expect(page.locator('h1')).toContainText('記事一覧');
+    
+    // 記事リストが存在するかチェック
+    const articleList = page.locator('[role="list"]');
+    const listExists = await articleList.count() > 0;
+    
+    if (listExists) {
+      const articles = page.locator('[role="list"] li');
+      const count = await articles.count();
+      
+      // 記事がない場合でも、レイアウトが正常に表示されている
+      if (count === 0) {
+        await expect(page.locator('h1')).toBeVisible();
+        await expect(page.locator('p')).toContainText('企業別の技術記事を確認できます');
+      }
+    }
+  });
+
+  test('レスポンシブデザインが正常に動作する', async ({ page }) => {
+    // モバイルサイズでテスト
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/articles');
+    await page.waitForLoadState('networkidle');
+    
+    // 記事一覧のロードを待機
+    await page.waitForSelector('h1', { timeout: 10000 });
+    
+    // ヘッダーが表示されている
+    await expect(page.locator('h1')).toBeVisible();
+    
+    // 記事リストが存在する場合
+    const articleList = page.locator('[role="list"]');
+    const listExists = await articleList.count() > 0;
+    
+    if (listExists) {
+      const articles = page.locator('[role="list"] li');
+      const count = await articles.count();
+      
+      if (count > 0) {
+        // 最初の記事が表示されている
+        const firstArticle = articles.first();
+        await expect(firstArticle).toBeVisible();
+        
+        // モバイルでも記事タイトルが読める
+        const titleLink = firstArticle.locator('a');
+        await expect(titleLink).toBeVisible();
+      }
+    }
+    
+    // デスクトップサイズに戻す
+    await page.setViewportSize({ width: 1280, height: 720 });
+  });
+});


### PR DESCRIPTION
## 概要
企業属性を確認できる記事一覧ページを実装しました。

## 実装内容
### バックエンド
- 記事一覧API(`/api/articles`)の実装
- 企業・プラットフォーム属性を含む記事一覧取得
- 企業IDとプラットフォームIDでのフィルタリング機能
- ページネーション機能（20件/ページ）
- 日付の降順ソート

### フロントエンド
- 記事一覧ページ(`/articles`)の実装
- 企業名、ロゴ、プラットフォーム、ブックマーク数の表示
- ページネーション機能
- レスポンシブデザイン対応
- ローディング・エラー状態の表示

### テスト
- バックエンドAPIの包括的なテスト（5テストケース）
- フロントエンドコンポーネントの包括的なテスト（7テストケース）
- フィルタリング、ソート、ページネーション機能のテスト

## 動作確認
- 全テストケースが通過
- コードスタイルチェック（Pint）が通過
- 静的解析（PHPStan）が通過
- フロントエンドビルドが成功

## 関連Issue
Closes #104

🤖 Generated with [Claude Code](https://claude.ai/code)