### PR TITLE
feat: テストカバレッジディレクトリの統一

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,12 +31,9 @@ node_modules
 # Test Coverage
 /coverage-html
 coverage-clover.xml
-coverage-test.xml
 coverage.txt
 coverage.xml
-/coverage_report
 
 # Playwright E2E Test Results
 /playwright-report/
 /test-results/
-/coverage/

--- a/README_COVERAGE.md
+++ b/README_COVERAGE.md
@@ -27,16 +27,24 @@ bash .github/scripts/check-coverage.sh 97.0
 ```
 
 ### カバレッジレポート生成
+
+**重要**: カバレッジレポートは以下のディレクトリ・ファイルに統一して出力してください。
+- **HTMLレポート**: `coverage-html` ディレクトリ
+- **XMLレポート**: `coverage-clover.xml`
+- **テキストレポート**: `coverage.txt`
+
 ```bash
-# HTMLレポート生成
+# HTMLレポート生成（統一ディレクトリ: coverage-html）
 php artisan test --coverage-html=coverage-html
 
-# テキストレポート生成
+# テキストレポート生成（統一ファイル: coverage.txt）
 php artisan test --coverage-text
 
-# XML（CI/CD用）レポート生成
-php artisan test --coverage-clover=coverage.xml
+# XML（CI/CD用）レポート生成（統一ファイル: coverage-clover.xml）
+php artisan test --coverage-clover=coverage-clover.xml
 ```
+
+**注意**: `coverage/` や `coverage_report/` などの異なるディレクトリは使用しないでください。
 
 ## カバレッジ向上の領域
 

--- a/docs/wiki/開発フロー.md
+++ b/docs/wiki/開発フロー.md
@@ -236,6 +236,10 @@ npx playwright show-report
 # PHPUnit テスト実行
 php artisan test
 
+# テストカバレッジ確認
+php artisan test --coverage-html=coverage-html
+# 注意: カバレッジレポートは必ず coverage-html ディレクトリに出力してください
+
 # コードスタイルチェック（自動修正）
 vendor/bin/pint
 


### PR DESCRIPTION
## Summary
- テストカバレッジディレクトリを `coverage-html` に統一
- gitignoreの重複記述を整理し、不要なディレクトリを削除
- ドキュメントにカバレッジレポート統一ディレクトリを明記

## Test plan
- [x] .gitignoreの重複記述を整理
- [x] README_COVERAGE.mdにカバレッジレポート統一ディレクトリを明記
- [x] 開発フロー.mdにテストカバレッジ確認コマンドを追加
- [x] 不要なディレクトリ（coverage/, coverage_report/）を削除
- [x] CI/CDとローカル環境で同じディレクトリ構成を確認

Closes #167

🤖 Generated with [Claude Code](https://claude.ai/code)