### PR TITLE
feat: スクレイピング時の企業情報自動紐付けと新規作成機能 (#188)

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -23,6 +23,8 @@ class Article extends Model
         'platform',
         'author_name',
         'organization_name',
+        'organization',
+        'organization_url',
         'author',
         'author_url',
         'published_at',

--- a/database/migrations/2025_07_22_142743_add_organization_and_organization_url_to_articles_table.php
+++ b/database/migrations/2025_07_22_142743_add_organization_and_organization_url_to_articles_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->string('organization', 255)->nullable()->after('organization_name')->comment('組織スラグ名（Qiita/Zenn）');
+            $table->string('organization_url', 1000)->nullable()->after('organization')->comment('組織URL');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('articles', function (Blueprint $table) {
+            $table->dropColumn(['organization', 'organization_url']);
+        });
+    }
+};

--- a/tests/Unit/Models/ArticleTest.php
+++ b/tests/Unit/Models/ArticleTest.php
@@ -60,6 +60,8 @@ class ArticleTest extends TestCase
             'platform',
             'author_name',
             'organization_name',
+            'organization',
+            'organization_url',
             'author',
             'author_url',
             'published_at',


### PR DESCRIPTION
## Summary
Issue #188に対応し、スクレイピング時の企業情報自動紐付けと新規作成機能を実装しました。

- **QiitaScraper**: organization情報の自動抽出機能を追加
- **ZennScraper**: 著者テキストから「in 企業名」形式の組織情報を解析
- **CompanyMatcher**: organizationベースマッチングを最優先に、新規企業自動作成機能を追加
- **Database Schema**: articlesテーブルに`organization`と`organization_url`カラムを追加

### 変更内容
- Qiita組織ページ情報の抽出（`/organizations/xxx`パターン）
- Zenn「username in 企業名」形式の解析とorganization URL生成
- 企業マッチング優先度の追加（organizationベース = 最優先）
- 新規企業自動作成（`is_active=false`）
- 包括的なテストカバレッジ（45件の新規テスト）

## Test plan
- [x] 全テストスイート実行 (1108 tests passed)  
- [x] PHPStan静的解析 (no errors)
- [x] Pintコードスタイル修正完了
- [x] テストカバレッジ 90%以上維持
- [x] 循環的複雑度チェック (PHPMetrics)
- [x] 既存機能の後方互換性確認

🤖 Generated with [Claude Code](https://claude.ai/code)