### PR TITLE
はてなブックマークスクレイピングでQiita/Zenn記事の除外機能を実装

### DIFF
--- a/app/Services/HatenaBookmarkScraper.php
+++ b/app/Services/HatenaBookmarkScraper.php
@@ -64,6 +64,7 @@ class HatenaBookmarkScraper extends BaseScraper
                         'url' => $url,
                         'domain' => $domain,
                     ]);
+
                     return; // continueと同じ効果
                 }
 
@@ -145,7 +146,7 @@ class HatenaBookmarkScraper extends BaseScraper
     /**
      * 指定されたドメインが除外対象かチェック
      *
-     * @param string $domain チェック対象のドメイン
+     * @param  string  $domain  チェック対象のドメイン
      * @return bool 除外対象の場合true
      */
     protected function isExcludedDomain(string $domain): bool
@@ -156,7 +157,7 @@ class HatenaBookmarkScraper extends BaseScraper
 
         foreach ($this->excludedDomains as $excludedDomain) {
             // 完全一致またはサブドメインを含む一致をチェック
-            if ($domain === $excludedDomain || str_ends_with($domain, '.' . $excludedDomain)) {
+            if ($domain === $excludedDomain || str_ends_with($domain, '.'.$excludedDomain)) {
                 return true;
             }
         }

--- a/config/scraping.php
+++ b/config/scraping.php
@@ -71,6 +71,10 @@ return [
             'timeout' => env('HATENA_SCRAPING_TIMEOUT', 30),
             'base_url' => \App\Constants\Platform::getUrl(\App\Constants\Platform::HATENA_BOOKMARK),
             'api_url' => 'https://bookmark.hatenaapis.com',
+            'excluded_domains' => [
+                'qiita.com',
+                'zenn.dev',
+            ],
         ],
 
         'qiita' => [


### PR DESCRIPTION
## 概要
はてなブックマークのスクレイピング処理において、QiitaやZennの記事が混入する問題を解決するため、設定ベースの除外機能を実装しました。

## 変更内容
- **config/scraping.php**: `excluded_domains`設定を追加し、qiita.com、zenn.devを除外対象に設定
- **HatenaBookmarkScraper**: `isExcludedDomain`メソッドを実装し、サブドメインも含めた除外判定を追加
- **parseResponse**: スクレイピング処理中にリアルタイムで除外チェックを実行
- **テスト拡張**: 29個のテストケースで除外機能の動作を包括的に検証

## 技術的特徴
- **実行順非依存**: スクレイピング処理内でリアルタイムに除外判定
- **設定駆動**: 除外対象ドメインを設定ファイルで柔軟に管理
- **サブドメイン対応**: api.qiita.com等のサブドメインも除外
- **パフォーマンス向上**: 不要な記事を早期に除外し処理効率を改善

## テスト
- [x] 単体テスト: 29/29 passed
- [x] PHPStan静的解析: エラーなし
- [x] 除外機能の境界値テスト完了
- [x] サブドメインパターンの検証完了

## 確認方法
```bash
# スクレイピング実行（除外機能が適用される）
php artisan scrape:platform hatena_bookmark

# テスト実行
php artisan test tests/Unit/Services/HatenaBookmarkScraperTest.php
```

Closes #194

🤖 Generated with [Claude Code](https://claude.ai/code)